### PR TITLE
Added ability to check which entity a pick collides with in collision manager.

### DIFF
--- a/SluaghEngine/Core/CameraManager.cpp
+++ b/SluaghEngine/Core/CameraManager.cpp
@@ -161,6 +161,27 @@ DirectX::XMFLOAT4X4 SE::Core::CameraManager::GetViewProjection(const Entity& ent
 	ProfileReturnConst(retMat);
 }
 
+void SE::Core::CameraManager::WorldSpaceRayFromScreenPos(int x, int y, int screenWidth, int screenHeight, DirectX::XMVECTOR& origin, DirectX::XMVECTOR& direction) const
+{
+	const size_t index = currentActive.activeCamera;
+	XMMATRIX proj = XMMatrixPerspectiveFovLH(cameraData.fov[index], cameraData.aspectRatio[index], cameraData.nearPlane[index], cameraData.farPlane[index]);
+	XMFLOAT4X4 projF;
+	XMStoreFloat4x4(&projF, proj);
+	XMMATRIX view = XMLoadFloat4x4(&cameraData.view[index]);
+	XMMATRIX invView = XMMatrixInverse(nullptr, view);
+
+	float xNDC = ((2.0f * x) / screenWidth) - 1;
+	float yNDC = -(((2.0f * y) / screenHeight) - 1);
+
+	float xView = xNDC / projF._11;
+	float yView = yNDC / projF._22;
+	direction = XMVector3Normalize(XMVector4Transform(XMVectorSet(xView, yView, 1.0f, 0.0f), invView));
+	XMFLOAT3 pos = transformManager->GetPosition(currentActive.entity);
+	origin = XMVectorSet(pos.x, pos.y, pos.z, 1.0f);
+	
+
+}
+
 void SE::Core::CameraManager::SetActive(const Entity & entity)
 {
 	StartProfile;

--- a/SluaghEngine/Core/DebugRenderManager.cpp
+++ b/SluaghEngine/Core/DebugRenderManager.cpp
@@ -197,7 +197,7 @@ void SE::Core::DebugRenderManager::GarbageCollection()
 	StartProfile;
 	uint32_t alive_in_row = 0;
 	size_t activeJobs = entityToJobID.size();
-	while (activeJobs > 0 && alive_in_row < 4U)
+	while (activeJobs > 0 && alive_in_row < 40U)
 	{
 		const std::uniform_int_distribution<uint32_t> distribution(0U, activeJobs - 1U);
 		uint32_t i = distribution(generator);

--- a/SluaghEngine/Test/ConsoleTest.cpp
+++ b/SluaghEngine/Test/ConsoleTest.cpp
@@ -1,6 +1,7 @@
 #include "ConsoleTest.h"
 #include <Core\Engine.h>
 #include <Utilz\Timer.h>
+#include <sstream>
 using namespace SE;
 using namespace SE::Core;
 SE::Test::ConsoleTest::ConsoleTest()
@@ -21,6 +22,7 @@ bool SE::Test::ConsoleTest::Run(Utilz::IConsoleBackend * console)
 	auto& cm = engine.GetCameraManager();
 	auto& rm = engine.GetRenderableManager();
 	auto& dc = engine.GetDevConsole();
+	auto& com = engine.GetCollisionManager();
 
 	Entity cube = em.Create();
 	Entity camera = em.Create();
@@ -28,6 +30,7 @@ bool SE::Test::ConsoleTest::Run(Utilz::IConsoleBackend * console)
 	tm.Create(camera, { 0,0,-5.0f });
 	rm.CreateRenderableObject(cube, "Placeholder_Block.mesh");
 	rm.ToggleRenderableObject(cube, true);
+	com.CreateBoundingHierarchy(cube, "Placeholder_Block.mesh");
 	CameraBindInfoStruct cbis;
 	cbis.aspectRatio = 1280.0f / 720.0f;
 	cm.Bind(camera, cbis);
@@ -42,7 +45,8 @@ bool SE::Test::ConsoleTest::Run(Utilz::IConsoleBackend * console)
 		PRINT_MESSAGE,
 		PRINT_ERROR,
 		ALLOCATE,
-		DEALLOCATE
+		DEALLOCATE,
+		CLICK
 	};
 	window->MapActionButton(TOGGLE_CONSOLE, Window::Key1);
 	window->MapActionButton(EXIT, Window::KeyEscape);
@@ -50,6 +54,7 @@ bool SE::Test::ConsoleTest::Run(Utilz::IConsoleBackend * console)
 	window->MapActionButton(PRINT_ERROR, Window::Key3);
 	window->MapActionButton(ALLOCATE, Window::KeyP);
 	window->MapActionButton(DEALLOCATE, Window::KeyO);
+	window->MapActionButton(CLICK, Window::MouseLeft);
 	std::vector<std::string> graphTest;
 	Utilz::Timer timer;
 
@@ -95,6 +100,23 @@ bool SE::Test::ConsoleTest::Run(Utilz::IConsoleBackend * console)
 			if(graphTest.size())
 				graphTest.pop_back();
 		}
+
+		if(window->ButtonPressed(CLICK))
+		{
+			int x, y;
+			DirectX::XMVECTOR dir;
+			DirectX::XMVECTOR ori;
+			window->GetMousePos(x, y);
+			cm.WorldSpaceRayFromScreenPos(x, y, window->Width(), window->Height(), ori, dir);
+			Entity ent;
+			if(com.Pick(ori, dir, ent))
+			{
+				std::stringstream ss;
+				ss << "Picked entity: " << ent.id;
+				dc.Print(ss.str(), "Picking");
+			}
+		}
+		
 
 		if(cameraControls)
 		{

--- a/SluaghEngine/Window/WindowSDL.cpp
+++ b/SluaghEngine/Window/WindowSDL.cpp
@@ -585,6 +585,16 @@ bool SE::Window::WindowSDL::RegisterOnEventCallback(const OnEventCallback & call
 	return true;
 }
 
+int SE::Window::WindowSDL::Width() const
+{
+	return width;
+}
+
+int SE::Window::WindowSDL::Height() const
+{
+	return height;
+}
+
 
 bool SE::Window::WindowSDL::SetWindow(int inHeight, int inWidth, bool inFullscreen)
 {

--- a/SluaghEngine/Window/WindowSDL.h
+++ b/SluaghEngine/Window/WindowSDL.h
@@ -62,7 +62,14 @@ namespace SE
 			bool RegisterOnEventCallback(const OnEventCallback& callback) override;
 
 
-			
+			/*
+			* @brief Returns the width of the window.
+			*/
+			int Width() const override;
+			/*
+			* @brief Returns the height of the window.
+			*/
+			int Height() const override;
 		
 			bool SetWindow(int inHeight, int inWidth, bool inFullscreen) override;
 		private:

--- a/SluaghEngine/includes/Core/CameraManager.h
+++ b/SluaghEngine/includes/Core/CameraManager.h
@@ -70,6 +70,8 @@ namespace SE
 			* @retval Returns the combined view/projection matrix if the entity has a camera component. Returns an identity matrix otherwise.
 			*/
 			DirectX::XMFLOAT4X4 GetViewProjection(const Entity& entity);
+
+			void WorldSpaceRayFromScreenPos(int x, int y, int screenWidth, int screenHeight, DirectX::XMVECTOR& origin, DirectX::XMVECTOR& direction) const;
 			/**
 			* @brief	Set the camera as the active camera.
 			*/

--- a/SluaghEngine/includes/Core/CollisionManager.h
+++ b/SluaghEngine/includes/Core/CollisionManager.h
@@ -83,6 +83,16 @@ namespace SE
 			*/
 			bool PickEntity(const Entity & entity, const DirectX::XMVECTOR & rayO, const DirectX::XMVECTOR & rayD, float * distance);
 
+			/**
+			* @brief	Check if the entity is hit by a ray.
+			* @param[in] rayO The origin of the ray.
+			* @param[in] rayD The direction of the ray.
+			* @param[out] collidedEntity The entity that the ray collided with.
+			* @retval true Returns true if an entity was written to collidedEntity
+			* @retval false Returns false if the ray did not collide with an entity
+			*/
+			bool Pick(const DirectX::XMVECTOR& rayO, const DirectX::XMVECTOR& rayD, Entity& collidedEntity) const;
+
 
 			inline void RegisterCollideWithAnyCallback(const CollideCallback& callback)
 			{

--- a/SluaghEngine/includes/Window/IWindow.h
+++ b/SluaghEngine/includes/Window/IWindow.h
@@ -356,6 +356,15 @@ namespace SE
 			*/
 			virtual void UnbindCallbacks() = 0;
 
+			/*
+			 * @brief Returns the width of the window.
+			 */
+			virtual int Width() const = 0;
+			/*
+			* @brief Returns the height of the window.
+			*/
+			virtual int Height() const = 0;
+
 			/*@TODO Add method to unregister a single callback. Needs operator== for delegates for that. (OR returning handles to the callback but that's cumbersome)*/
 
 			/**


### PR DESCRIPTION
How to print it to the console is visible in ConsoleTest.cpp. There's not really any reason to hardcode "Check if pick picks anything every time the user clicks" into the engine.