### PR TITLE
Temporary fix for inverting animations

### DIFF
--- a/SluaghEngine/FBX_Converter/FBXConverter.cpp
+++ b/SluaghEngine/FBX_Converter/FBXConverter.cpp
@@ -1607,18 +1607,21 @@ void SE::FBX::FBXConverter::WriteSkeleton(string folderName, Skeleton skeleton, 
 		// Define the ofstream 
 		ofstream outBinary(binaryFile, std::ios::binary);
 
+		// Define the number of joints
 		uint32_t nrOfJoints = (uint32_t)skeleton.hierarchy.size();
 
 		// Write the skeleton header
 		outBinary.write(reinterpret_cast<char*>(&nrOfJoints), sizeof(uint32_t));
+
+		FbxAMatrix scaling;
+		FbxVector4 scale = { 1.0f, 1.0f, -1.0f };
+		scaling.SetS(scale);
 
 		for (int jointIndex = 0; jointIndex < skeleton.hierarchy.size(); jointIndex++) {
 
 			// Get the bindpose and joint parent index
 			uint32_t parentIndex = skeleton.hierarchy[jointIndex].ParentIndex;
 			XMFLOAT4X4 bindPoseMatrix = Load4X4Transformations(skeleton.hierarchy[jointIndex].GlobalBindposeInverse);
-			
-			//XMStoreFloat4x4(&bindPoseMatrix, XMMatrixTranspose(XMLoadFloat4x4(&Load4X4Transformations(skeleton.hierarchy[jointIndex].GlobalBindposeInverse))));
 
 			outBinary.write(reinterpret_cast<char*>(&parentIndex), sizeof(uint32_t));
 			outBinary.write(reinterpret_cast<char*>(&bindPoseMatrix), sizeof(XMFLOAT4X4));

--- a/SluaghEngine/FBX_Converter/FBXConverter.cpp
+++ b/SluaghEngine/FBX_Converter/FBXConverter.cpp
@@ -1613,10 +1613,6 @@ void SE::FBX::FBXConverter::WriteSkeleton(string folderName, Skeleton skeleton, 
 		// Write the skeleton header
 		outBinary.write(reinterpret_cast<char*>(&nrOfJoints), sizeof(uint32_t));
 
-		FbxAMatrix scaling;
-		FbxVector4 scale = { 1.0f, 1.0f, -1.0f };
-		scaling.SetS(scale);
-
 		for (int jointIndex = 0; jointIndex < skeleton.hierarchy.size(); jointIndex++) {
 
 			// Get the bindpose and joint parent index
@@ -1770,7 +1766,7 @@ void SE::FBX::FBXConverter::ConvertToLeftHanded(FbxAMatrix &matrix) {
 
 	// Get the translation and rotation from the matrix to be processed
 	FbxVector4 translation = matrix.GetT();
-	FbxVector4 rotation = matrix.GetR();
+	FbxQuaternion rotation = matrix.GetQ();
 
 	// To convert to DirectX left handed coordinate system, we negate the z-translation and xy rotation in the matrix
 
@@ -1779,7 +1775,7 @@ void SE::FBX::FBXConverter::ConvertToLeftHanded(FbxAMatrix &matrix) {
 
 	// Update the matrix with the converted translation and rotation
 	matrix.SetT(translation);
-	matrix.SetR(rotation);
+	matrix.SetQ(rotation);
 }
 
 FbxMesh* SE::FBX::FBXConverter::GetMeshFromRoot(FbxNode* node, string meshName) {	// Function to receive a mesh from the root node

--- a/SluaghEngine/Graphics/AnimationSystem.cpp
+++ b/SluaghEngine/Graphics/AnimationSystem.cpp
@@ -131,7 +131,7 @@ void SE::Graphics::AnimationSystem::UpdateAnimation(int animIndex, int skeletonI
 		b.GlobalTx = interpolatedJointTransforms[i];
 
 		// Create the matrix by multiplying the joint global transformation with the inverse bind pose
-		XMStoreFloat4x4(at + i, XMMatrixTranspose(b.inverseBindPoseMatrix * b.GlobalTx));
+		XMStoreFloat4x4(at + i, XMMatrixTranspose(b.inverseBindPoseMatrix * b.GlobalTx * XMMatrixScaling(-1, 1, 1)));
 
 		int a = 0;
 	}


### PR DESCRIPTION
A temporary fix to correctly display animations by scaling the final transformation matrix with a scaling in  the negative x-axis