### PR TITLE
Added texture channel in material file

### DIFF
--- a/SluaghEngine/FBX_Converter/FBXConverter.cpp
+++ b/SluaghEngine/FBX_Converter/FBXConverter.cpp
@@ -1295,7 +1295,7 @@ void SE::FBX::FBXConverter::LoadMaterial(Mesh& pMesh) {
 		else if (surfaceMaterial->GetClassId() == FbxSurfacePhong::ClassId) {
 
 			FbxSurfacePhong* phongMaterial = (FbxSurfacePhong*)surfaceMaterial;
-			GetLambert(pMesh.objectMaterial, phongMaterial);
+			GetPhong(pMesh.objectMaterial, phongMaterial);
 		}
 
 		// Get the texture on the diffuse material property
@@ -1309,7 +1309,7 @@ void SE::FBX::FBXConverter::LoadMaterial(Mesh& pMesh) {
 	}
 }
 
-void SE::FBX::FBXConverter::GetLambert(Material objectMaterial, FbxSurfaceLambert* lambertMaterial) {
+void SE::FBX::FBXConverter::GetLambert(Material& objectMaterial, FbxSurfaceLambert* lambertMaterial) {
 
 	objectMaterial.materialType = "Lambert";
 
@@ -1340,7 +1340,7 @@ void SE::FBX::FBXConverter::GetLambert(Material objectMaterial, FbxSurfaceLamber
 	objectMaterial.specularFactor = 0.0f;
 }
 
-void SE::FBX::FBXConverter::GetPhong(Material objectMaterial, FbxSurfacePhong* phongMaterial) {
+void SE::FBX::FBXConverter::GetPhong(Material& objectMaterial, FbxSurfacePhong* phongMaterial) {
 
 	objectMaterial.materialType = "Phong";
 

--- a/SluaghEngine/FBX_Converter/FBXConverter.cpp
+++ b/SluaghEngine/FBX_Converter/FBXConverter.cpp
@@ -1388,6 +1388,7 @@ void SE::FBX::FBXConverter::GetChannelTexture(Mesh& pMesh, FbxProperty materialP
 
 			texture.texturePath = Utilz::getFilename(textureFile->GetFileName());
 			texture.textureName = Utilz::removeExtension(Utilz::getFilename(textureFile->GetFileName()));
+			texture.textureChannel = materialProperty.GetName();
 
 			pMesh.objectMaterial.textures.push_back(texture);
 		}
@@ -1465,7 +1466,7 @@ void SE::FBX::FBXConverter::Write() {
 void SE::FBX::FBXConverter::WriteMaterial(string folderName, string textureFolder, Material& meshMaterial) {
 
 	// Define the file name
-	string binaryFile = folderName + "/" + meshMaterial.materialName + "_" + fileName + ".mat";
+	string binaryFile = folderName + "/" + fileName + ".mat";
 
 	// Define the ofstream 
 	ofstream outBinary(binaryFile, std::ios::binary);
@@ -1502,11 +1503,19 @@ void SE::FBX::FBXConverter::WriteMaterial(string folderName, string textureFolde
 
 		if(ExportTexture(meshMaterial.textures[textureIndex], textureFolder)) {
 
+			// Write the texture name
 			uint32_t size = (uint32_t)meshMaterial.textures[textureIndex].textureName.size();
 			string textureName = meshMaterial.textures[textureIndex].textureName;
 
 			outBinary.write(reinterpret_cast<char*>(&size), sizeof(uint32_t));
 			outBinary.write(reinterpret_cast<char*>(&textureName), size);
+
+			// Write the texture channel
+			size = (uint32_t)meshMaterial.textures[textureIndex].textureChannel.size();
+			string textureChannel = meshMaterial.textures[textureIndex].textureChannel;
+
+			outBinary.write(reinterpret_cast<char*>(&size), sizeof(uint32_t));
+			outBinary.write(reinterpret_cast<char*>(&textureChannel), size);
 
 			cout << "[OK] Exported " << meshMaterial.textures[textureIndex].textureName << " to " << textureFolder << endl;
 		}

--- a/SluaghEngine/FBX_Converter/FBXConverter.cpp
+++ b/SluaghEngine/FBX_Converter/FBXConverter.cpp
@@ -1505,7 +1505,7 @@ void SE::FBX::FBXConverter::WriteMaterial(string folderName, string textureFolde
 
 			// Write the texture name
 			uint32_t size = (uint32_t)meshMaterial.textures[textureIndex].textureName.size();
-			string textureName = meshMaterial.textures[textureIndex].textureName;
+			string textureName = meshMaterial.textures[textureIndex].textureName + ".sei";
 
 			outBinary.write(reinterpret_cast<char*>(&size), sizeof(uint32_t));
 			outBinary.write(reinterpret_cast<char*>(&textureName), size);

--- a/SluaghEngine/includes/FBX_Converter/Datatypes.h
+++ b/SluaghEngine/includes/FBX_Converter/Datatypes.h
@@ -79,6 +79,7 @@ namespace SE
 
 			string textureName;
 			string texturePath;
+			string textureChannel;
 
 			Texture() {
 

--- a/SluaghEngine/includes/FBX_Converter/FBXConverter.h
+++ b/SluaghEngine/includes/FBX_Converter/FBXConverter.h
@@ -88,8 +88,8 @@ namespace SE
 			//----------------------------------------------------------------------------------------------------------------------------------//
 
 			void LoadMaterial(Mesh& pMesh);
-			void GetLambert(Material objectMaterial, FbxSurfaceLambert* lambertMaterial);
-			void GetPhong(Material objectMaterial, FbxSurfacePhong* phongMaterial);
+			void GetLambert(Material& objectMaterial, FbxSurfaceLambert* lambertMaterial);
+			void GetPhong(Material& objectMaterial, FbxSurfacePhong* phongMaterial);
 			void GetChannelTexture(Mesh& pMesh, FbxProperty materialProperty);
 			bool ExportTexture(Texture &texture, string textureFolder);
 


### PR DESCRIPTION
Added a string to the texture datatype in FBXConverter to specify which channel the texture is currently bound to. "DiffuseColor" or "NormalMap".