### PR TITLE
Weapon pickup spawn

### DIFF
--- a/SluaghEngine/Core/Core.vcxproj
+++ b/SluaghEngine/Core/Core.vcxproj
@@ -105,6 +105,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);DLL_EXPORT_CORE</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)Build\lib\$(Platform)\$(TargetName).dll" "$(SolutionDir)Test"</Command>
@@ -116,6 +117,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);DLL_EXPORT_CORE</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)Build\lib\$(Platform)\$(TargetName).dll" "$(SolutionDir)Test"</Command>
@@ -129,6 +131,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);DLL_EXPORT_CORE</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -146,6 +149,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);DLL_EXPORT_CORE</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -157,7 +161,9 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AnimationSystem.cpp" />
+    <ClCompile Include="DataManager.cpp" />
     <ClCompile Include="EventManager.cpp" />
+    <ClCompile Include="IDataManager.cpp" />
     <ClCompile Include="IEventManager.cpp" />
     <ClCompile Include="ITextManager.cpp" />
     <ClCompile Include="RenderableManagerInstancing.cpp" />
@@ -197,6 +203,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\includes\Core\Entity.h" />
+    <ClInclude Include="..\includes\Core\IDataManager.h" />
     <ClInclude Include="..\includes\Core\IEventManager.h" />
     <ClInclude Include="..\includes\Core\ITextManager.h" />
     <ClInclude Include="..\includes\Core\IAnimationManager.h" />
@@ -217,6 +224,7 @@
     <ClInclude Include="..\includes\Core\ITransformManager.h" />
     <ClInclude Include="AnimationStructs.h" />
     <ClInclude Include="AnimationSystem.h" />
+    <ClInclude Include="DataManager.h" />
     <ClInclude Include="EventManager.h" />
     <ClInclude Include="RenderableManagerInstancing.h" />
     <ClInclude Include="TextManager.h" />

--- a/SluaghEngine/Core/Core.vcxproj.filters
+++ b/SluaghEngine/Core/Core.vcxproj.filters
@@ -147,6 +147,12 @@
     <ClCompile Include="DecalManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="IDataManager.cpp">
+      <Filter>Interface\cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="DataManager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AudioManager.h">
@@ -267,6 +273,12 @@
       <Filter>Interface</Filter>
     </ClInclude>
     <ClInclude Include="EventManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\Core\IDataManager.h">
+      <Filter>Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="DataManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SluaghEngine/Core/DataManager.cpp
+++ b/SluaghEngine/Core/DataManager.cpp
@@ -1,35 +1,65 @@
 #include "DataManager.h"
+#include <Profiler.h>
 
 
-
-SE::Core::DataManager::DataManager()
+SE::Core::DataManager::DataManager(const IDataManager::InitializationInfo& info) : initInfo(info)
 {
 }
 
 
 SE::Core::DataManager::~DataManager()
 {
+
 }
 
-void SE::Core::DataManager::AddValue(const Entity entity, const Utilz::GUID key, const values value)
+void SE::Core::DataManager::SetValue(const Entity entity, const Utilz::GUID key, const values value)
 {
+	StartProfile;
+	auto const find = entityToIndex.find(entity);
+
+	if (find == entityToIndex.end())
+		CreateData(entity);
+	
+	entries[entityToIndex[entity]].value = value;
+	
+	StopProfile;
 }
 
 SE::Core::DataManager::values SE::Core::DataManager::GetValue(const Entity entity, const Utilz::GUID key, const values default_value)
 {
-	return values();
+	StartProfile;
+	const auto find = entityToIndex.find(entity);
+	if (find == entityToIndex.end())
+		ProfileReturnConst(default_value);
+	ProfileReturnConst(entries[find->second].value);
 }
 
 void SE::Core::DataManager::Frame(Utilz::TimeCluster * timer)
 {
-}
+	_ASSERT(timer);
+	StartProfile;
+	timer->Start("DataManager");
+	GarbageCollection();
 
-void SE::Core::DataManager::Allocate(size_t size)
-{
+	timer->Stop("DataManager");
+	StopProfile;
 }
 
 void SE::Core::DataManager::Destroy(size_t index)
 {
+	StartProfile;
+	uint32_t last = entries.size() - 1;
+	const Entity e = entries[index].entity;
+	const Entity last_e = entries[last].entity;
+
+	entries[index].entity = entries[last].entity;
+	entries[index].value = entries[last].value;
+
+	entityToIndex[last_e] = index;
+	entityToIndex.erase(e);
+
+	entries.pop_back();
+	StopProfile;
 }
 
 void SE::Core::DataManager::Destroy(const Entity & entity)
@@ -38,4 +68,27 @@ void SE::Core::DataManager::Destroy(const Entity & entity)
 
 void SE::Core::DataManager::GarbageCollection()
 {
+	StartProfile;
+	uint32_t alive_in_row = 0;
+	while (entries.size() > 0 && alive_in_row < 4U)
+	{
+		std::uniform_int_distribution<size_t> distribution(0U, entries.size() - 1U);
+		size_t i = distribution(generator);
+		if (initInfo.entityManager->Alive(entries[i].entity))
+		{
+			alive_in_row++;
+			continue;
+		}
+		alive_in_row = 0;
+		Destroy(i);
+	}
+	StopProfile;
+}
+
+void SE::Core::DataManager::CreateData(const Entity entity)
+{
+	StartProfile;
+	size_t index = entityToIndex[entity] = entityToIndex.size();
+	entries.push_back({ entity });
+	ProfileReturnVoid;
 }

--- a/SluaghEngine/Core/DataManager.cpp
+++ b/SluaghEngine/Core/DataManager.cpp
@@ -20,7 +20,7 @@ void SE::Core::DataManager::SetValue(const Entity entity, const Utilz::GUID key,
 	if (find == entityToIndex.end())
 		CreateData(entity);
 	
-	entries[entityToIndex[entity]].value = value;
+	entries[entityToIndex[entity]].values[key] = value;
 	
 	StopProfile;
 }
@@ -31,7 +31,10 @@ SE::Core::DataManager::values SE::Core::DataManager::GetValue(const Entity entit
 	const auto find = entityToIndex.find(entity);
 	if (find == entityToIndex.end())
 		ProfileReturnConst(default_value);
-	ProfileReturnConst(entries[find->second].value);
+	auto const findV = entries[find->second].values.find(key);
+	if (findV == entries[find->second].values.end())
+		ProfileReturnConst(default_value);
+	ProfileReturnConst(findV->second);
 }
 
 void SE::Core::DataManager::Frame(Utilz::TimeCluster * timer)
@@ -53,7 +56,7 @@ void SE::Core::DataManager::Destroy(size_t index)
 	const Entity last_e = entries[last].entity;
 
 	entries[index].entity = entries[last].entity;
-	entries[index].value = entries[last].value;
+	entries[index].values = entries[last].values;
 
 	entityToIndex[last_e] = index;
 	entityToIndex.erase(e);

--- a/SluaghEngine/Core/DataManager.cpp
+++ b/SluaghEngine/Core/DataManager.cpp
@@ -1,0 +1,41 @@
+#include "DataManager.h"
+
+
+
+SE::Core::DataManager::DataManager()
+{
+}
+
+
+SE::Core::DataManager::~DataManager()
+{
+}
+
+void SE::Core::DataManager::AddValue(const Entity entity, const Utilz::GUID key, const values value)
+{
+}
+
+SE::Core::DataManager::values SE::Core::DataManager::GetValue(const Entity entity, const Utilz::GUID key, const values default_value)
+{
+	return values();
+}
+
+void SE::Core::DataManager::Frame(Utilz::TimeCluster * timer)
+{
+}
+
+void SE::Core::DataManager::Allocate(size_t size)
+{
+}
+
+void SE::Core::DataManager::Destroy(size_t index)
+{
+}
+
+void SE::Core::DataManager::Destroy(const Entity & entity)
+{
+}
+
+void SE::Core::DataManager::GarbageCollection()
+{
+}

--- a/SluaghEngine/Core/DataManager.h
+++ b/SluaghEngine/Core/DataManager.h
@@ -37,7 +37,7 @@ namespace SE
 			struct Entry
 			{
 				Entity entity;
-				values value;
+				std::unordered_map<Utilz::GUID, values, Utilz::GUID::Hasher> values;
 			};
 
 			std::vector<Entry> entries;

--- a/SluaghEngine/Core/DataManager.h
+++ b/SluaghEngine/Core/DataManager.h
@@ -1,0 +1,44 @@
+#ifndef SE_CORE_DATA_MANAGER_H_
+#define SE_CORE_DATA_MANAGER_H_
+
+#include <IDataManager.h>
+
+namespace SE
+{
+	namespace Core
+	{
+		class DataManager : public IDataManager
+		{
+		public:
+			DataManager();
+			~DataManager();
+
+			void AddValue(const Entity entity, const Utilz::GUID key, const values value)override;
+			values GetValue(const Entity entity, const Utilz::GUID key, const values default_value) override;
+
+			/**
+			* @brief	Called each frame, to update the state.
+			*/
+			void Frame(Utilz::TimeCluster* timer)override;
+		private:
+			/**
+			* @brief	Allocate more memory
+			*/
+			void Allocate(size_t size);
+			/**
+			* @brief	Remove an enitity entry
+			*/
+			void Destroy(size_t index)override;
+			/**
+			* @brief	Remove an enitity entry
+			*/
+			void Destroy(const Entity& entity)override;
+			/**
+			* @brief	Look for dead entities.
+			*/
+			void GarbageCollection()override;
+		};
+	}
+}
+
+#endif // SE_CORE_DATA_MANAGER_H_

--- a/SluaghEngine/Core/DataManager.h
+++ b/SluaghEngine/Core/DataManager.h
@@ -2,6 +2,7 @@
 #define SE_CORE_DATA_MANAGER_H_
 
 #include <IDataManager.h>
+#include <random>
 
 namespace SE
 {
@@ -10,10 +11,10 @@ namespace SE
 		class DataManager : public IDataManager
 		{
 		public:
-			DataManager();
+			DataManager(const IDataManager::InitializationInfo& info);
 			~DataManager();
 
-			void AddValue(const Entity entity, const Utilz::GUID key, const values value)override;
+			void SetValue(const Entity entity, const Utilz::GUID key, const values value)override;
 			values GetValue(const Entity entity, const Utilz::GUID key, const values default_value) override;
 
 			/**
@@ -21,13 +22,6 @@ namespace SE
 			*/
 			void Frame(Utilz::TimeCluster* timer)override;
 		private:
-			/**
-			* @brief	Allocate more memory
-			*/
-			void Allocate(size_t size);
-			/**
-			* @brief	Remove an enitity entry
-			*/
 			void Destroy(size_t index)override;
 			/**
 			* @brief	Remove an enitity entry
@@ -37,6 +31,21 @@ namespace SE
 			* @brief	Look for dead entities.
 			*/
 			void GarbageCollection()override;
+
+			void CreateData(const Entity entity);
+			
+			struct Entry
+			{
+				Entity entity;
+				values value;
+			};
+
+			std::vector<Entry> entries;
+			std::unordered_map<Entity, size_t, EntityHasher> entityToIndex;
+
+			IDataManager::InitializationInfo initInfo;
+			std::default_random_engine generator;
+
 		};
 	}
 }

--- a/SluaghEngine/Core/DecalManager.cpp
+++ b/SluaghEngine/Core/DecalManager.cpp
@@ -288,6 +288,12 @@ void SE::Core::DecalManager::Destroy(size_t index)
 	bucket->second.owners.pop_back();
 	
 	entityToTransformIndex.erase(entity);
+
+	if (bucket->second.world.size() == 0)
+	{
+		initInfo.renderer->RemoveRenderJob(decalToJobID[texture]);
+		decalToJobID.erase(texture);
+	}
 	ProfileReturnVoid;
 }
 

--- a/SluaghEngine/Core/Engine.cpp
+++ b/SluaghEngine/Core/Engine.cpp
@@ -131,7 +131,6 @@ int SE::Core::Engine::Release()
 		delete *rit;
 
 	delete managers.entityManager;
-	delete managers.eventManager;
 
 	if(subSystems.devConsole)
 		subSystems.devConsole->Shutdown();

--- a/SluaghEngine/Core/Engine.cpp
+++ b/SluaghEngine/Core/Engine.cpp
@@ -237,12 +237,12 @@ void SE::Core::Engine::InitManagers()
 	if (!managers.entityManager)
 		managers.entityManager = CreateEntityManager();
 
+	InitDataManager();
+
 	if (!managers.eventManager)
-		managers.eventManager = CreateEventManager({managers.entityManager});
+		managers.eventManager = CreateEventManager({ subSystems.window, managers.entityManager, managers.dataManager });
 	managersVec.push_back(managers.eventManager);
 
-
-	InitDataManager();
 	InitTransformManager();
 	InitAudioManager();
 	InitParticleSystemManager();

--- a/SluaghEngine/Core/Engine.cpp
+++ b/SluaghEngine/Core/Engine.cpp
@@ -239,10 +239,11 @@ void SE::Core::Engine::InitManagers()
 		managers.entityManager = CreateEntityManager();
 
 	if (!managers.eventManager)
-		managers.eventManager = CreateEventManager();
+		managers.eventManager = CreateEventManager({managers.entityManager});
+	managersVec.push_back(managers.eventManager);
 
 
-	
+	InitDataManager();
 	InitTransformManager();
 	InitAudioManager();
 	InitParticleSystemManager();
@@ -256,6 +257,7 @@ void SE::Core::Engine::InitManagers()
 	InitTextManager();
 	InitGUIManager();
 	InitDecalManager();
+
 	StopProfile;
 }
 
@@ -450,6 +452,17 @@ void SE::Core::Engine::InitDecalManager()
 		managers.decalManager = CreateDecalManager(info);
 	}
 	managersVec.push_back(managers.decalManager);
+}
+
+void SE::Core::Engine::InitDataManager()
+{
+	if (!managers.dataManager)
+	{
+		IDataManager::InitializationInfo info;
+		info.entityManager = managers.entityManager;
+		managers.dataManager = CreateDataManager(info);
+	}
+	managersVec.push_back(managers.dataManager);
 }
 
 void SE::Core::Engine::SetupDebugConsole()

--- a/SluaghEngine/Core/Engine.h
+++ b/SluaghEngine/Core/Engine.h
@@ -127,6 +127,7 @@ namespace SE
 			void InitTextManager();
 			void InitGUIManager();
 			void InitDecalManager();
+			void InitDataManager();
 
 			void SetupDebugConsole();
 

--- a/SluaghEngine/Core/EventManager.cpp
+++ b/SluaghEngine/Core/EventManager.cpp
@@ -2,11 +2,37 @@
 
 
 
-SE::Core::EventManager::EventManager()
+SE::Core::EventManager::EventManager(const IEventManager::InitializationInfo& info)
 {
 }
 
 
 SE::Core::EventManager::~EventManager()
+{
+}
+
+void SE::Core::EventManager::RegisterEventCallback(const Utilz::GUID _event, 
+	const std::function<void(const Entity, const std::vector<void*>&args)> _eventTriggerCallback,
+	const std::function<bool(const Entity, std::vector<void*>&args)> _eventTriggerCheck)
+{
+}
+
+void SE::Core::EventManager::SetLifetime(const Entity entity, float lifetime)
+{
+}
+
+void SE::Core::EventManager::Frame(Utilz::TimeCluster * timer)
+{
+}
+
+void SE::Core::EventManager::Destroy(size_t index)
+{
+}
+
+void SE::Core::EventManager::Destroy(const Entity & entity)
+{
+}
+
+void SE::Core::EventManager::GarbageCollection()
 {
 }

--- a/SluaghEngine/Core/EventManager.cpp
+++ b/SluaghEngine/Core/EventManager.cpp
@@ -1,5 +1,5 @@
 #include "EventManager.h"
-
+#include <Profiler.h>
 
 
 SE::Core::EventManager::EventManager(const IEventManager::InitializationInfo& info)
@@ -23,6 +23,14 @@ void SE::Core::EventManager::SetLifetime(const Entity entity, float lifetime)
 
 void SE::Core::EventManager::Frame(Utilz::TimeCluster * timer)
 {
+	StartProfile;
+	_ASSERT(timer);
+	timer->Start("EventManager");
+
+
+
+	timer->Stop("EventManager");
+	StopProfile;
 }
 
 void SE::Core::EventManager::Destroy(size_t index)

--- a/SluaghEngine/Core/EventManager.cpp
+++ b/SluaghEngine/Core/EventManager.cpp
@@ -2,8 +2,9 @@
 #include <Profiler.h>
 
 
-SE::Core::EventManager::EventManager(const IEventManager::InitializationInfo& info)
+SE::Core::EventManager::EventManager(const IEventManager::InitializationInfo& info) : initInfo(info)
 {
+	Allocate(10);
 }
 
 
@@ -19,6 +20,13 @@ void SE::Core::EventManager::RegisterEventCallback(const Utilz::GUID _event,
 
 void SE::Core::EventManager::SetLifetime(const Entity entity, float lifetime)
 {
+	auto const find = entityToIndex.find(entity);
+	if (find == entityToIndex.end())
+	{
+		size_t index = entityToIndex[entity] = eventData.used++;
+		eventData.entity[index] = entity;
+		initInfo.dataManager->SetValue(entity, "TimeToDeath", lifetime);
+	}
 }
 
 void SE::Core::EventManager::Frame(Utilz::TimeCluster * timer)
@@ -26,15 +34,70 @@ void SE::Core::EventManager::Frame(Utilz::TimeCluster * timer)
 	StartProfile;
 	_ASSERT(timer);
 	timer->Start("EventManager");
-
-
+	float dt = initInfo.window->GetDelta();
+	for (size_t i = 0; i < eventData.used; i++)
+	{
+		float timeToDeath = std::get<float>(initInfo.dataManager->GetValue(eventData.entity[i], "TimeToDeath", -1.0f));
+		if (timeToDeath >= 0)
+		{
+			timeToDeath -= dt;
+			if (timeToDeath <= 0)
+			{
+				initInfo.entityManager->Destroy(eventData.entity[i]);
+				Destroy(i);
+				continue;
+			}
+			initInfo.dataManager->SetValue(eventData.entity[i], "TimeToDeath", timeToDeath);
+		}
+	}
 
 	timer->Stop("EventManager");
 	StopProfile;
 }
 
+void SE::Core::EventManager::Allocate(size_t size)
+{
+	StartProfile;
+	_ASSERT(size > eventData.allocated);
+
+	// Allocate new memory
+	EventData newData;
+	newData.allocated = size;
+	newData.data = operator new(size * EventData::size);
+	newData.used = eventData.used;
+
+	// Setup the new pointers
+	newData.entity = (Entity*)newData.data;
+	newData.events = (Events*)(newData.entity + newData.allocated);
+
+	// Copy data
+	memcpy(newData.entity, eventData.entity, eventData.used * sizeof(Entity));
+	memcpy(newData.events, eventData.events, eventData.used * sizeof(Events));
+
+	// Delete old data;
+	operator delete(eventData.data);
+	eventData = newData;
+	StopProfile;
+}
+
 void SE::Core::EventManager::Destroy(size_t index)
 {
+	StartProfile;
+	// Temp variables
+	size_t last = eventData.used - 1;
+	const Entity entity = eventData.entity[index];
+	const Entity last_entity = eventData.entity[last];
+
+	// Copy the data
+	eventData.entity[index] = last_entity;
+	eventData.events[index] = eventData.events[last];
+
+	// Replace the index for the last_entity 
+	entityToIndex[last_entity] = index;
+	entityToIndex.erase(entity);
+
+	eventData.used--;
+
 }
 
 void SE::Core::EventManager::Destroy(const Entity & entity)
@@ -43,4 +106,19 @@ void SE::Core::EventManager::Destroy(const Entity & entity)
 
 void SE::Core::EventManager::GarbageCollection()
 {
+	StartProfile;
+	uint32_t alive_in_row = 0;
+	while (eventData.used > 0 && alive_in_row < 50U)
+	{
+		std::uniform_int_distribution<size_t> distribution(0U, eventData.used - 1U);
+		size_t i = distribution(generator);
+		if (initInfo.entityManager->Alive(eventData.entity[i]))
+		{
+			alive_in_row++;
+			continue;
+		}
+		alive_in_row = 0;
+		Destroy(i);
+	}
+	StopProfile;
 }

--- a/SluaghEngine/Core/EventManager.h
+++ b/SluaghEngine/Core/EventManager.h
@@ -17,8 +17,9 @@ namespace SE
 
 
 			void RegisterEventCallback(const Utilz::GUID _event,
-				const std::function<void(const Entity, const std::vector<void*>& args)> _eventTriggerCallback,
-				const std::function<bool(const Entity, std::vector<void*>& args)> _eventTriggerCheck)override;
+				const EventCallbacks& callbacks)override;
+		
+			void RegisterEntitytoEvent(const Entity entity, const Utilz::GUID _event) override;
 
 			void SetLifetime(const Entity entity, float lifetime)override;
 
@@ -84,7 +85,7 @@ namespace SE
 			struct Events
 			{
 				static const uint8_t MAX = 8;
-				uint8_t nrOfEvents;
+				uint8_t nrOfEvents = 0;
 				Utilz::GUID event_[MAX];
 
 			};
@@ -103,6 +104,8 @@ namespace SE
 
 			IEventManager::InitializationInfo initInfo;
 			std::default_random_engine generator;
+
+			std::unordered_map<Utilz::GUID, EventCallbacks, Utilz::GUID::Hasher> eventToCallbacks;
 
 		};
 	}

--- a/SluaghEngine/Core/EventManager.h
+++ b/SluaghEngine/Core/EventManager.h
@@ -3,6 +3,8 @@
 #include <IEventManager.h>
 #include <Utilz\Event.h>
 #include <unordered_map>
+#include <random>
+
 namespace SE
 {
 	namespace Core
@@ -63,7 +65,10 @@ namespace SE
 			Utilz::Event<void(const Entity& entity)> UpdateRenderableObject;
 			Utilz::Event<void(const Entity&, bool)> ToggleVisibleEvent;
 
-
+			/**
+			* @brief	Allocate more memory
+			*/
+			void Allocate(size_t size);
 			/**
 			* @brief	Remove an enitity entry
 			*/
@@ -76,20 +81,28 @@ namespace SE
 			* @brief	Look for dead entities.
 			*/
 			void GarbageCollection() override;
+			struct Events
+			{
+				static const uint8_t MAX = 8;
+				uint8_t nrOfEvents;
+				Utilz::GUID event_[MAX];
 
+			};
 			struct EventData
 			{
-				static const size_t size = sizeof(Entity);
+				static const size_t size = sizeof(Entity) + sizeof(Events);
 				size_t allocated = 0;
 				size_t used = 0;
 				void* data = nullptr;
 				Entity* entity;
+				Events* events;
 			};
 
 			EventData eventData;
 			std::unordered_map<Entity, size_t, EntityHasher> entityToIndex;
 
-
+			IEventManager::InitializationInfo initInfo;
+			std::default_random_engine generator;
 
 		};
 	}

--- a/SluaghEngine/Core/IDataManager.cpp
+++ b/SluaghEngine/Core/IDataManager.cpp
@@ -1,0 +1,6 @@
+#include <IDataManager.h>
+#include "DataManager.h"
+DECLDIR_CORE SE::Core::IDataManager * SE::Core::CreateDataManager(const IDataManager::InitializationInfo & info)
+{
+	return new DataManager(info);
+}

--- a/SluaghEngine/Core/IEventManager.cpp
+++ b/SluaghEngine/Core/IEventManager.cpp
@@ -1,7 +1,7 @@
 #include <IEventManager.h>
 #include "EventManager.h"
 
-DECLDIR_CORE SE::Core::IEventManager * SE::Core::CreateEventManager()
+DECLDIR_CORE SE::Core::IEventManager * SE::Core::CreateEventManager(const IEventManager::InitializationInfo& info)
 {
-	return new EventManager;
+	return new EventManager(info);
 }

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -131,7 +131,7 @@ void Room::Update(float dt, float playerX, float playerY)
 			CoreInit::managers.eventManager->SetLifetime(bs, 10);
 
 			auto spw = CoreInit::subSystems.window->GetRand() % 100000;
-			if (true)//spw > 50000)
+			if (spw > 50000)
 			{
 				auto wep = CoreInit::managers.entityManager->Create();
 				CoreInit::managers.renderableManager->CreateRenderableObject(wep, { "default.mesh" });
@@ -141,9 +141,9 @@ void Room::Update(float dt, float playerX, float playerY)
 				CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "WeaponPickUp");
 				CoreInit::managers.dataManager->SetValue(wep, "Weapon", true);
 				CoreInit::managers.dataManager->SetValue(wep, "Damage", 100);
-				CoreInit::managers.dataManager->SetValue(wep, "Type", 0);
-				CoreInit::managers.dataManager->SetValue(wep, "Name", "xXx_Killer_Blaster_xXx");
-
+				CoreInit::managers.dataManager->SetValue(wep, "Type", 0/*0 is sword*/);
+				CoreInit::managers.dataManager->SetValue(wep, "Element", 0/*0 is physical*/);
+				CoreInit::managers.dataManager->SetValue(wep, "Name", "xXx_Killer_Slasher_Naruto_Killer_xXx"s);
 			}
 			
 			delete enemyUnits[i];

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -131,10 +131,13 @@ void Room::Update(float dt, float playerX, float playerY)
 			CoreInit::managers.eventManager->SetLifetime(bs, 10);
 
 			auto spw = CoreInit::subSystems.window->GetRand() % 100000;
-			if (spw > 50000)
+			if (true)//spw > 50000)
 			{
 				auto wep = CoreInit::managers.entityManager->Create();
-				CoreInit::managers.renderableManager->CreateRenderableObject(wep, { "Cube.mesh" });
+				CoreInit::managers.renderableManager->CreateRenderableObject(wep, { "default.mesh" });
+				CoreInit::managers.renderableManager->ToggleRenderableObject(wep, true);
+				CoreInit::managers.transformManager->Create(wep, p, {}, { 0.2f,0.2f,0.2f });
+				CoreInit::managers.collisionManager->CreateBoundingHierarchy(wep, "default.mesh");
 				CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "WeaponPickUp");
 				CoreInit::managers.dataManager->SetValue(wep, "Weapon", true);
 				CoreInit::managers.dataManager->SetValue(wep, "Damage", 100);

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -128,7 +128,7 @@ void Room::Update(float dt, float playerX, float playerY)
 			Core::DecalCreateInfo ci;
 			ci.textureName = "bloodSpatt.png";			
 			CoreInit::managers.decalManager->Create(bs, ci);
-
+			CoreInit::managers.eventManager->SetLifetime(bs, 10);
 
 			delete enemyUnits[i];
 			enemyUnits[i] = enemyUnits.back();

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -119,10 +119,20 @@ void Room::Update(float dt, float playerX, float playerY)
 	{
 		if (!enemyUnits[i]->IsAlive())
 		{
+			// Blood spatter
+			auto bs = CoreInit::managers.entityManager->Create();
+			
+			CoreInit::managers.transformManager->Create(bs, { enemyUnits[i]->GetXPosition(), enemyUnits[i]->GetYPosition(), enemyUnits[i]->GetZPosition() }, { DirectX::XM_PIDIV2, 0,0 });
+			Core::DecalCreateInfo ci;
+			ci.textureName = "BlackPink.sei";			
+			CoreInit::managers.decalManager->Create(bs, ci);
+
+
 			delete enemyUnits[i];
 			enemyUnits[i] = enemyUnits.back();
 			enemyUnits.pop_back();
 		}
+
 	}
 
 	StopProfile;

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -121,10 +121,12 @@ void Room::Update(float dt, float playerX, float playerY)
 		{
 			// Blood spatter
 			auto bs = CoreInit::managers.entityManager->Create();
-			
-			CoreInit::managers.transformManager->Create(bs, { enemyUnits[i]->GetXPosition(), enemyUnits[i]->GetYPosition(), enemyUnits[i]->GetZPosition() }, { DirectX::XM_PIDIV2, 0,0 });
+			auto p = CoreInit::managers.transformManager->GetPosition(enemyUnits[i]->GetEntity());
+			p.y = 0;
+			CoreInit::managers.transformManager->Create(bs, p, { DirectX::XM_PIDIV2, 0,0 }, {1,1, 0.05f});
+		
 			Core::DecalCreateInfo ci;
-			ci.textureName = "BlackPink.sei";			
+			ci.textureName = "bloodSpatt.png";			
 			CoreInit::managers.decalManager->Create(bs, ci);
 
 

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -128,7 +128,7 @@ void Room::Update(float dt, float playerX, float playerY)
 			Core::DecalCreateInfo ci;
 			ci.textureName = "bloodSpatt.png";			
 			CoreInit::managers.decalManager->Create(bs, ci);
-			CoreInit::managers.eventManager->SetLifetime(bs, 10);
+			CoreInit::managers.eventManager->SetLifetime(bs, 60);
 
 			auto spw = CoreInit::subSystems.window->GetRand() % 100000;
 			if (spw > 50000)

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -130,6 +130,19 @@ void Room::Update(float dt, float playerX, float playerY)
 			CoreInit::managers.decalManager->Create(bs, ci);
 			CoreInit::managers.eventManager->SetLifetime(bs, 10);
 
+			auto spw = CoreInit::subSystems.window->GetRand() % 100000;
+			if (spw > 50000)
+			{
+				auto wep = CoreInit::managers.entityManager->Create();
+				CoreInit::managers.renderableManager->CreateRenderableObject(wep, { "Cube.mesh" });
+				CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "WeaponPickUp");
+				CoreInit::managers.dataManager->SetValue(wep, "Weapon", true);
+				CoreInit::managers.dataManager->SetValue(wep, "Damage", 100);
+				CoreInit::managers.dataManager->SetValue(wep, "Type", 0);
+				CoreInit::managers.dataManager->SetValue(wep, "Name", "xXx_Killer_Blaster_xXx");
+
+			}
+			
 			delete enemyUnits[i];
 			enemyUnits[i] = enemyUnits.back();
 			enemyUnits.pop_back();

--- a/SluaghEngine/Particle_Editor/Particle_Editor.vcxproj
+++ b/SluaghEngine/Particle_Editor/Particle_Editor.vcxproj
@@ -98,6 +98,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)Build\lib\$(Platform)\*.dll" "$(ProjectDir)"</Command>
@@ -108,6 +109,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
       <Command>copy /Y "$(SolutionDir)Build\lib\$(Platform)\*.dll" "$(ProjectDir)"</Command>
@@ -120,6 +122,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -136,6 +139,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/SluaghEngine/includes/Core/IDataManager.h
+++ b/SluaghEngine/includes/Core/IDataManager.h
@@ -1,0 +1,43 @@
+#ifndef SE_CORE_INTERFACE_DATA_MANAGER_H_
+#define SE_CORE_INTERFACE_DATA_MANAGER_H_
+
+
+#if defined DLL_EXPORT_CORE
+#define DECLDIR_CORE __declspec(dllexport)
+#else
+#define DECLDIR_CORE __declspec(dllimport)
+#endif
+
+#include "IManager.h"
+#include <Utilz\GUID.h>
+#include <variant>
+
+namespace SE
+{
+	namespace Core
+	{
+		class IDataManager : public IManager
+		{
+		public:
+			struct InitializationInfo
+			{
+				IEntityManager* entityManager;
+			};
+
+			typedef std::variant<bool, uint32_t, float, std::string>  values;
+
+			virtual void AddValue(const Entity entity, const Utilz::GUID key, const values value) = 0;
+			virtual values GetValue(const Entity entity, const Utilz::GUID key, const values default_value) = 0;
+
+		protected:
+			IDataManager() {};
+		};
+
+		/**
+		* @brief Create an instance of the DataManager
+		**/
+		DECLDIR_CORE IDataManager* CreateDataManager(const IDataManager::InitializationInfo& info);
+	}
+}
+
+#endif //SE_CORE_INTERFACE_DATA_MANAGER_H_

--- a/SluaghEngine/includes/Core/IDataManager.h
+++ b/SluaghEngine/includes/Core/IDataManager.h
@@ -11,6 +11,7 @@
 #include "IManager.h"
 #include <Utilz\GUID.h>
 #include <variant>
+using namespace std::literals;
 
 namespace SE
 {

--- a/SluaghEngine/includes/Core/IDataManager.h
+++ b/SluaghEngine/includes/Core/IDataManager.h
@@ -27,7 +27,26 @@ namespace SE
 
 			typedef std::variant<bool, int32_t, float, std::string>  values;
 
+			/**
+			* @brief	Set the value of a variable. If new variable it will be created.
+			*
+			* @param[in] entity The entity.
+			* @param[in] key The variable name.
+			* @param[in] value The value.
+			* @warning String must be passed with the suffix s, "A String"s. Otherwise it will be casted to a bool.
+			*
+			*/
 			virtual void SetValue(const Entity entity, const Utilz::GUID key, const values value) = 0;
+
+			/**
+			* @brief	Get the value of a variable, if it does not exist return a default.
+			*
+			* @param[in] entity The entity.
+			* @param[in] key The variable name.
+			* @param[in] default_value The default value if not found.
+			* @warning String must be passed with the suffix s, "A String"s. Otherwise it will be casted to a bool.
+			*
+			*/
 			virtual values GetValue(const Entity entity, const Utilz::GUID key, const values default_value) = 0;
 
 		protected:

--- a/SluaghEngine/includes/Core/IDataManager.h
+++ b/SluaghEngine/includes/Core/IDataManager.h
@@ -24,9 +24,9 @@ namespace SE
 				IEntityManager* entityManager;
 			};
 
-			typedef std::variant<bool, uint32_t, float, std::string>  values;
+			typedef std::variant<bool, int32_t, float, std::string>  values;
 
-			virtual void AddValue(const Entity entity, const Utilz::GUID key, const values value) = 0;
+			virtual void SetValue(const Entity entity, const Utilz::GUID key, const values value) = 0;
 			virtual values GetValue(const Entity entity, const Utilz::GUID key, const values default_value) = 0;
 
 		protected:

--- a/SluaghEngine/includes/Core/IEngine.h
+++ b/SluaghEngine/includes/Core/IEngine.h
@@ -29,6 +29,7 @@
 #include "ITextManager.h"
 #include "IEventManager.h"
 #include "Utilz/ThreadPool.h"
+#include "IDataManager.h"
 
 namespace SE
 {
@@ -58,6 +59,7 @@ namespace SE
 				IGUIManager* guiManager = nullptr;
 				IDecalManager* decalManager = nullptr;
 				IEventManager* eventManager = nullptr;
+				IDataManager* dataManager = nullptr;
 			};
 			struct Subsystems
 			{

--- a/SluaghEngine/includes/Core/IEventManager.h
+++ b/SluaghEngine/includes/Core/IEventManager.h
@@ -32,15 +32,36 @@ namespace SE
 
 			struct EventCallbacks
 			{
-				std::function<void(const Entity, const std::vector<void*>& args)> triggerCallback;
+				std::function<void(const Entity, const std::vector<void*>& args)> triggerCallback; 
 				std::function<bool(const Entity, std::vector<void*>& args)> triggerCheck;
 			};
 
+			/**
+			* @brief	Register a new event
+			*
+			* @param[in] _event The event identifier.
+			* @param[in] callbacks The callbacks used to check if the event is trigger and to trigger the event.
+			*
+			*/
 			virtual void RegisterEventCallback(const Utilz::GUID _event,
 				const EventCallbacks& callbacks) = 0;
 
+			/**
+			* @brief	Register an event to an entity
+			*
+			* @param[in] entity The entity to bind the event to.
+			* @param[in] _event The event identifier.
+			*
+			*/
 			virtual void RegisterEntitytoEvent(const Entity entity, const Utilz::GUID _event) = 0;
 
+			/**
+			* @brief	Set the lifetime of an entity. When the time reaches 0 the entity will be destroyed
+			*
+			* @param[in] entity The entity to bind the event to.
+			* @param[in] lifetime The lifetime of the entity
+			*
+			*/
 			virtual void SetLifetime(const Entity entity, float lifetime) = 0;
 
 

--- a/SluaghEngine/includes/Core/IEventManager.h
+++ b/SluaghEngine/includes/Core/IEventManager.h
@@ -12,7 +12,8 @@
 #include <Utilz\Delegate.h>
 #include <Graphics\RenderJob.h>
 #include "IManager.h"
-
+#include "IDataManager.h"
+#include <Window\IWindow.h>
 namespace SE
 {
 	namespace Core
@@ -22,7 +23,9 @@ namespace SE
 		public:
 			struct InitializationInfo
 			{
+				Window::IWindow* window;
 				IEntityManager* entityManager;
+				IDataManager* dataManager;
 			};
 
 			virtual ~IEventManager() {};

--- a/SluaghEngine/includes/Core/IEventManager.h
+++ b/SluaghEngine/includes/Core/IEventManager.h
@@ -11,15 +11,29 @@
 #include "Entity.h"
 #include <Utilz\Delegate.h>
 #include <Graphics\RenderJob.h>
+#include "IManager.h"
 
 namespace SE
 {
 	namespace Core
 	{
-		class IEventManager
+		class IEventManager : public IManager
 		{
 		public:
+			struct InitializationInfo
+			{
+				IEntityManager* entityManager;
+			};
+
 			virtual ~IEventManager() {};
+
+			virtual void RegisterEventCallback(const Utilz::GUID _event,
+				const std::function<void(const Entity, const std::vector<void*>& args)> _eventTriggerCallback,
+				const std::function<bool(const Entity, std::vector<void*>& args)> _eventTriggerCheck) = 0;
+
+
+			virtual void SetLifetime(const Entity entity, float lifetime) = 0;
+
 
 			virtual void RegisterToSetRenderObjectInfo(const Utilz::Delegate<void(const Entity& entity, SE::Graphics::RenderJob* info)>&& callback) = 0;
 			virtual void TriggerSetRenderObjectInfo(const Entity& entity, SE::Graphics::RenderJob* info) = 0;
@@ -43,7 +57,7 @@ namespace SE
 		/**
 		* @brief Create an instance of the EventManager
 		**/
-		DECLDIR_CORE IEventManager* CreateEventManager();
+		DECLDIR_CORE IEventManager* CreateEventManager(const IEventManager::InitializationInfo& info);
 	}
 }
 

--- a/SluaghEngine/includes/Core/IEventManager.h
+++ b/SluaghEngine/includes/Core/IEventManager.h
@@ -30,10 +30,16 @@ namespace SE
 
 			virtual ~IEventManager() {};
 
-			virtual void RegisterEventCallback(const Utilz::GUID _event,
-				const std::function<void(const Entity, const std::vector<void*>& args)> _eventTriggerCallback,
-				const std::function<bool(const Entity, std::vector<void*>& args)> _eventTriggerCheck) = 0;
+			struct EventCallbacks
+			{
+				std::function<void(const Entity, const std::vector<void*>& args)> triggerCallback;
+				std::function<bool(const Entity, std::vector<void*>& args)> triggerCheck;
+			};
 
+			virtual void RegisterEventCallback(const Utilz::GUID _event,
+				const EventCallbacks& callbacks) = 0;
+
+			virtual void RegisterEntitytoEvent(const Entity entity, const Utilz::GUID _event) = 0;
 
 			virtual void SetLifetime(const Entity entity, float lifetime) = 0;
 


### PR DESCRIPTION
* Weapons(a pink cube) now has a 50% chance to spawn when killing an enemy.

* Blood is now splattered below an enemy when they die.
-- Blood splatter will be in the same location in every room...

* Event manager now support lifetimes for entities.

* Event manager now supports registering userdefined events to entities. This can/will be used for the weapon pickup system

- Added the DataManager. Including
-- The ability to register bool, int, float and string to an entity
-- Multiple variables for one entity.
-- WARNING!! Strings must have the suffic s, "asd"s

* This PR will resolve Bug #970

When I implemented this the Glasting did not have its model or animations. Probably because I didn't have the latest assets.
I have not changed any assets, but added a blood splatter texture. I will drop this off on Monday.


The PR is connected with Issue #902.
This issue includes randomizing stats, however I believe this can be included in Issue #900 instead.