### PR TITLE
Adaptive GC, bugfixes, optimisations

### DIFF
--- a/SluaghEngine/Core/AnimationManager.cpp
+++ b/SluaghEngine/Core/AnimationManager.cpp
@@ -256,26 +256,36 @@ void SE::Core::AnimationManager::Frame(Utilz::TimeCluster * timer)
 
 
 			// If an entity is attached to this entity...
+			//Make sure the attached entity is still alive.
+			
 			if (att.slots[k].attached == true) {
+				if (initInfo.entityManager->Alive(att.slots[k].entity))
+				{
 
-				// Get the joint transformation matrix
-				DirectX::XMFLOAT4X4 matrix;
-				animationSystem->GetJointMatrix(animationData.entity[i], att.slots[k].jointIndex, matrix);
-				DirectX::XMFLOAT4X4 parentTransform = initInfo.transformManager->GetTransform(animationData.entity[i]);
+					// Get the joint transformation matrix
+					DirectX::XMFLOAT4X4 matrix;
+					animationSystem->GetJointMatrix(animationData.entity[i], att.slots[k].jointIndex, matrix);
+					DirectX::XMFLOAT4X4 parentTransform = initInfo.transformManager->GetTransform(animationData.entity[i]);
 
-				// Get the joint inversed inverse bindpose
-				DirectX::XMMATRIX inverseBindPose = DirectX::XMMatrixIdentity();
-				animationSystem->GetJointInverseBindPose(animationData.animInfo[i].skeleton, att.slots[k].jointIndex, inverseBindPose);
-				inverseBindPose = DirectX::XMMatrixInverse(nullptr, inverseBindPose);
+					// Get the joint inversed inverse bindpose
+					DirectX::XMMATRIX inverseBindPose = DirectX::XMMatrixIdentity();
+					animationSystem->GetJointInverseBindPose(animationData.animInfo[i].skeleton, att.slots[k].jointIndex, inverseBindPose);
+					inverseBindPose = DirectX::XMMatrixInverse(nullptr, inverseBindPose);
 
-				// Decompose the joint transformation matrix
-				DirectX::XMVECTOR jointScale, jointQuat, jointTrans;
-				DirectX::XMMatrixDecompose(&jointScale, &jointQuat, &jointTrans, inverseBindPose * XMLoadFloat4x4(&matrix) * XMLoadFloat4x4(&parentTransform));
+					// Decompose the joint transformation matrix
+					DirectX::XMVECTOR jointScale, jointQuat, jointTrans;
+					DirectX::XMMatrixDecompose(&jointScale, &jointQuat, &jointTrans, inverseBindPose * XMLoadFloat4x4(&matrix) * XMLoadFloat4x4(&parentTransform));
 
-				DirectX::XMFLOAT4X4 transform;
-				DirectX::XMFLOAT4X4 localTransform = initInfo.transformManager->GetTransform(att.slots[k].entity);
-				DirectX::XMStoreFloat4x4(&transform, XMLoadFloat4x4(&localTransform) * inverseBindPose * XMLoadFloat4x4(&matrix) * XMLoadFloat4x4(&parentTransform));
-				initInfo.transformManager->SetTransform(att.slots[k].entity, transform);
+					DirectX::XMFLOAT4X4 transform;
+					DirectX::XMFLOAT4X4 localTransform = initInfo.transformManager->GetTransform(att.slots[k].entity);
+					DirectX::XMStoreFloat4x4(&transform, XMLoadFloat4x4(&localTransform) * inverseBindPose * XMLoadFloat4x4(&matrix) * XMLoadFloat4x4(&parentTransform));
+					initInfo.transformManager->SetTransform(att.slots[k].entity, transform);
+				}
+				else
+				{
+					
+					initInfo.console->Print(("Entity " +std::to_string(att.slots[k].entity.id) +  " attached to joint was not alive.").c_str());
+				}
 
 			}
 		}

--- a/SluaghEngine/Core/RenderableManager.cpp
+++ b/SluaghEngine/Core/RenderableManager.cpp
@@ -3,7 +3,7 @@
 
 #include <Graphics\VertexStructs.h>
 #include <Graphics\FileHeaders.h>
-
+#undef max
 #ifdef _DEBUG
 #pragma comment(lib, "UtilzD.lib")
 #else
@@ -600,7 +600,8 @@ void SE::Core::RenderableManager::GarbageCollection()
 {
 	StartProfile;
 	uint32_t alive_in_row = 0;
-	while (renderableObjectInfo.used > 0 && alive_in_row < 50U)
+	const uint32_t quitWhenReached = std::max((uint32_t)(renderableObjectInfo.used * 0.005f), 40U);
+	while (renderableObjectInfo.used > 0 && alive_in_row < quitWhenReached)
 	{
 		std::uniform_int_distribution<size_t> distribution(0U, renderableObjectInfo.used - 1U);
 		size_t i = distribution(generator);

--- a/SluaghEngine/Core/RenderableManager.cpp
+++ b/SluaghEngine/Core/RenderableManager.cpp
@@ -38,7 +38,7 @@ SE::Core::RenderableManager::RenderableManager(const IRenderableManager::Initial
 {
 	Init();
 
-	shadowInstancing = new RenderableManagerInstancing(initInfo.renderer);
+	shadowInstancing = nullptr;// new RenderableManagerInstancing(initInfo.renderer);
 	
 
 	Allocate(allocsize);

--- a/SluaghEngine/Core/RenderableManagerInstancing.cpp
+++ b/SluaghEngine/Core/RenderableManagerInstancing.cpp
@@ -77,11 +77,7 @@ void SE::Core::RenderableManagerInstancing::UpdateTransform(const Entity & entit
 	auto find = entityToBucketAndIndexInBucket.find(entity);
 
 	if(find != entityToBucketAndIndexInBucket.end()){
-
-		DirectX::XMFLOAT4X4 transposed;
-		DirectX::XMStoreFloat4x4(&transposed, DirectX::XMMatrixTranspose(DirectX::XMLoadFloat4x4(&transform)));
-		pipelineToRenderBucket[find->second.bucket]->transforms[find->second.index] = transposed;
-
+		DirectX::XMStoreFloat4x4(&pipelineToRenderBucket[find->second.bucket]->transforms[find->second.index], DirectX::XMMatrixTranspose(DirectX::XMLoadFloat4x4(&transform)));
 	}
 
 	StopProfile;

--- a/SluaghEngine/Core/TransformManager.cpp
+++ b/SluaghEngine/Core/TransformManager.cpp
@@ -377,6 +377,7 @@ void SE::Core::TransformManager::Frame(Utilz::TimeCluster* timer)
 {
 	_ASSERT(timer);
 	StartProfile;
+	GarbageCollection();
 	timer->Start(("TransformManager"));
 	auto LoopDirty = [this](int start, int end)
 	{
@@ -413,7 +414,7 @@ void SE::Core::TransformManager::Frame(Utilz::TimeCluster* timer)
 		}
 	}
 
-	GarbageCollection();
+	
 	timer->Stop(("TransformManager"));
 	StopProfile;
 }

--- a/SluaghEngine/Core/TransformManager.cpp
+++ b/SluaghEngine/Core/TransformManager.cpp
@@ -396,10 +396,11 @@ void SE::Core::TransformManager::Frame(Utilz::TimeCluster* timer)
 		return true;
 	};
 	
-	/*auto job1 = initInfo.threadPool->Enqueue(LoopDirty, 0, data.used / 2);
-	auto job2 = initInfo.threadPool->Enqueue(LoopDirty, data.used / 4, data.used / 2);
+	auto job1 = initInfo.threadPool->Enqueue(LoopDirty, 0, data.used / 2);
+	/*auto job2 = initInfo.threadPool->Enqueue(LoopDirty, data.used / 4, data.used / 2);
 	auto job3 = initInfo.threadPool->Enqueue(LoopDirty, data.used / 2, (data.used / 4) * 3);*/
-	LoopDirty(0, data.used);//(data.used / 4) * 3, data.used);
+	LoopDirty(data.used / 2, data.used);//(data.used / 4) * 3, data.used);
+	job1.get();
 	/*job1.get();
 	job2.get();
 	job3.get();*/

--- a/SluaghEngine/Core/TransformManager.cpp
+++ b/SluaghEngine/Core/TransformManager.cpp
@@ -385,12 +385,10 @@ void SE::Core::TransformManager::Frame(Utilz::TimeCluster* timer)
 		{
 			if (data.flags[i] & TransformFlags::DIRTY)
 			{
-				XMFLOAT4X4 transform;
 				const auto& translation = XMMatrixTranslationFromVector(XMLoadFloat3(&data.positions[i]));
 				const auto& rotation = XMMatrixRotationRollPitchYawFromVector(XMLoadFloat3(&data.rotations[i]));
 				const auto& scale = XMMatrixScalingFromVector(XMLoadFloat3(&data.scalings[i]));
-				XMStoreFloat4x4(&transform, scale*rotation*translation);
-				dirtyTransforms[i] = transform;
+				XMStoreFloat4x4(&dirtyTransforms[i], scale*rotation*translation);	
 			}
 		}
 		return true;

--- a/SluaghEngine/Core/TransformManager.cpp
+++ b/SluaghEngine/Core/TransformManager.cpp
@@ -350,10 +350,10 @@ void SE::Core::TransformManager::GarbageCollection()
 {
 	StartProfile;
 	uint32_t aliveInRow = 0;
-	const uint32_t quitWhenReached = std::max((uint32_t)(data.used * 0.005f), 40U);
+	const uint32_t quitWhenReached = std::max((uint32_t)(data.used * 0.02f), 40U);
 	while(data.used > 0 && aliveInRow < quitWhenReached)
 	{
-		std::uniform_int_distribution<size_t> distribution(0U, data.used - 1U);
+		const std::uniform_int_distribution<size_t> distribution(0U, data.used - 1U);
 		size_t i = distribution(generator);
 		if(initInfo.entityManager->Alive(data.entities[i]))
 		{

--- a/SluaghEngine/Core/TransformManager.cpp
+++ b/SluaghEngine/Core/TransformManager.cpp
@@ -350,7 +350,8 @@ void SE::Core::TransformManager::GarbageCollection()
 {
 	StartProfile;
 	uint32_t aliveInRow = 0;
-	while(data.used > 0 && aliveInRow < 40U)
+	const uint32_t quitWhenReached = std::max((uint32_t)(data.used * 0.05f), 40U);
+	while(data.used > 0 && aliveInRow < quitWhenReached)
 	{
 		std::uniform_int_distribution<size_t> distribution(0U, data.used - 1U);
 		size_t i = distribution(generator);

--- a/SluaghEngine/Core/TransformManager.cpp
+++ b/SluaghEngine/Core/TransformManager.cpp
@@ -350,7 +350,7 @@ void SE::Core::TransformManager::GarbageCollection()
 {
 	StartProfile;
 	uint32_t aliveInRow = 0;
-	const uint32_t quitWhenReached = std::max((uint32_t)(data.used * 0.05f), 40U);
+	const uint32_t quitWhenReached = std::max((uint32_t)(data.used * 0.005f), 40U);
 	while(data.used > 0 && aliveInRow < quitWhenReached)
 	{
 		std::uniform_int_distribution<size_t> distribution(0U, data.used - 1U);

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -118,7 +118,14 @@ void Room::Update(float dt, float playerX, float playerY)
 				
 			}
 			
+			
+			if(auto enemyWep = std::get_if<Core::Entity>(&CoreInit::managers.dataManager->GetValue(enemyUnits[i]->GetEntity(), "Weapon", false)))
+			{
+				CoreInit::managers.entityManager->DestroyNow(*enemyWep);
+			}
+			
 			delete enemyUnits[i];
+			
 			enemyUnits[i] = enemyUnits.back();
 			enemyUnits.pop_back();
 		}


### PR DESCRIPTION
Issue 969.

* Fixed crash when entity is attached to joint is destroyed and animation tries to update it.
* The transform manager now looks through more entities proportional to how many entities are registererd when performing the garbage collection. There was not really a noticable difference.
* The issue with stuff hanging around after being destroyed seems to be gone
* Re-enabled the threading in transformmanager matrix calculations.
*Small optimisations in the transform manager, Cut the frame time for the transformmanager in half. (Down from around 1 ms per frame to 0.5ms during "usual" gameplay.)
*Adaptive GC for the renderable manager, made no noticable difference.
*Small optimisation in RenderableManagerInstancing::UpdateTransform, skipping an extra copy of a matrix