### PR TITLE
Items are no longer static between rooms

### DIFF
--- a/SluaghEngine/Core/CollisionManager.cpp
+++ b/SluaghEngine/Core/CollisionManager.cpp
@@ -250,6 +250,11 @@ void SE::Core::CollisionManager::Frame(Utilz::TimeCluster* timer)
 			auto& mySphere = boundingHierarchy.sphere[boundingInfo[collisionData.boundingIndex[dirty.myIndex]].index];
 			auto& myAABB = boundingHierarchy.AABB[boundingInfo[collisionData.boundingIndex[dirty.myIndex]].index];
 			XMMATRIX myTransform = XMLoadFloat4x4(&tArr[dirty.transformIndex]);
+
+			auto tran = XMMatrixTranslationFromVector(XMLoadFloat3(&initInfo.transformManager->GetPosition(collisionData.entity[dirty.myIndex])));
+			auto rot = XMMatrixRotationRollPitchYawFromVector(XMLoadFloat3(&initInfo.transformManager->GetRotation(collisionData.entity[dirty.myIndex])));
+			myTransform = rot* tran;
+
 			mySphere.Transform(collisionData.sphereWorld[dirty.myIndex], myTransform);
 			myAABB.Transform(collisionData.AABBWorld[dirty.myIndex], myTransform);
 		}

--- a/SluaghEngine/Core/ParticleSystemManager.cpp
+++ b/SluaghEngine/Core/ParticleSystemManager.cpp
@@ -304,8 +304,6 @@ void SE::Core::ParticleSystemManager::ToggleVisible(const Entity& entity, bool v
 			// Tell renderer.
 			if (visible)
 			{
-				particleSystemData[find->second].firstRun = true;
-				particleSystemData[find->second].updateJob.vertexCount = 1;
 				particleSystemData[find->second].updateJobID = initInfo.renderer->AddRenderJob(
 					particleSystemData[find->second].updateJob, SE::Graphics::RenderGroup::PRE_PASS_0);
 				particleSystemData[find->second].renderJobID = initInfo.renderer->AddRenderJob(

--- a/SluaghEngine/Gameplay/Items.cpp
+++ b/SluaghEngine/Gameplay/Items.cpp
@@ -329,7 +329,7 @@ void SE::Gameplay::Item::Drop(Core::Entity ent, DirectX::XMFLOAT3 pos)
 {
 	CoreInit::managers.transformManager->SetPosition(ent, pos);
 	CoreInit::managers.transformManager->SetRotation(ent, 0,0,0);
-	CoreInit::managers.collisionManager->CreateBoundingHierarchy(ent, 0.8);
+	CoreInit::managers.collisionManager->CreateBoundingHierarchy(ent, 0.2);
 	CoreInit::managers.guiManager->ToggleRenderableTexture(ent, false);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, true);
 	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "WeaponPickUp");

--- a/SluaghEngine/Gameplay/PlayState.cpp
+++ b/SluaghEngine/Gameplay/PlayState.cpp
@@ -486,6 +486,8 @@ void SE::Gameplay::PlayState::InitWeaponPickups()
 		{
 			player->AddItem(ent, 4);
 		}
+
+		CoreInit::managers.dataManager->SetValue(ent, "Pickup", true);
 	};
 
 	pickUpEvent.triggerCheck = [pe](const Core::Entity ent, void* data) {

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -116,7 +116,8 @@ void Room::Update(float dt, float playerX, float playerY)
 				auto item = Item::Create();
 
 				Item::Drop(item, p);
-				
+				itemsInRoom.push_back(item);
+				CoreInit::managers.dataManager->SetValue(item, "Pickup", false);
 			//	CoreInit::managers.eventManager->RegisterEntitytoEvent(item, "RoomChange", &beingRendered);
 			}
 		
@@ -1052,6 +1053,15 @@ void SE::Gameplay::Room::CreateEntities()
 
 void SE::Gameplay::Room::RenderRoom(bool render)
 {
+
+	for (auto& i : itemsInRoom)
+	{
+		if (auto pickedup = std::get<bool>( CoreInit::managers.dataManager->GetValue(i, "Pickup", false)); pickedup == false)
+		{
+			CoreInit::managers.entityManager->Destroy(i);
+		}	
+	}
+	itemsInRoom.clear();
 	for (int i = 0; i < roomEntities.size(); i++)
 	{
 		

--- a/SluaghEngine/includes/Gameplay/Room.h
+++ b/SluaghEngine/includes/Gameplay/Room.h
@@ -34,6 +34,7 @@ namespace SE
 			std::vector<EnemyUnit*> enemyUnits;
 			FlowField* roomField;
 			std::vector<SE::Core::Entity> roomEntities;
+			std::vector<Core::Entity> itemsInRoom;
 			bool IsOutside = false;
 			enum class PropTypes
 			{


### PR DESCRIPTION
Items are now destroyed when the player transitions to another room.

It solves issue #1005 