### PR TITLE
Fixed decal crash #1128

### DIFF
--- a/SluaghEngine/Core/DecalManager.cpp
+++ b/SluaghEngine/Core/DecalManager.cpp
@@ -296,6 +296,13 @@ void SE::Core::DecalManager::Destroy(size_t index)
 		initInfo.renderer->RemoveRenderJob(decalToJobID[texture]);
 		decalToJobID.erase(texture);
 	}
+	else
+	{
+		initInfo.renderer->ChangeRenderJob(decalToJobID[texture], [](RenderJob& job)
+		{
+			--job.instanceCount;
+		});
+	}
 	ProfileReturnVoid;
 }
 


### PR DESCRIPTION
Issue #1128

The render job was not updated when a decal was removed.