### PR TITLE
Tutorial and Nuckelavee Fixes

### DIFF
--- a/SluaghEngine/Build/Asset/Shaders/Pixel/SimplePS.hlsl
+++ b/SluaghEngine/Build/Asset/Shaders/Pixel/SimplePS.hlsl
@@ -10,7 +10,7 @@ struct PS_IN
 
 float4 PS_main(PS_IN input) : SV_TARGET
 {
-	float3 dir = normalize(float3(-1.0f, -0.5f, 0.0f));
+	float3 dir = float3(-1.0f, -0.5f, 0.0f);
 	float lum = dot(input.NormalInW.xyz, -dir);
 	float3 color = float3(0.8, 0.1, 0.3)*lum;
 	return float4(color, 1.0f);

--- a/SluaghEngine/Build/Asset/Shaders/Pixel/SimpleTexPS.hlsl
+++ b/SluaghEngine/Build/Asset/Shaders/Pixel/SimpleTexPS.hlsl
@@ -14,8 +14,8 @@ struct PS_IN
 
 float4 PS_main(PS_IN input) : SV_TARGET
 {
-	float3 dir = normalize(float3(0.0f, -2.5f, 1.0f));
+	float3 dir = float3(-1.0f, -0.5f, 0.0f);
 	float lum = dot(input.NormalInW.xyz, -dir);
-	float3 color =  DiffuseColor.Sample(sampAni, input.Tex)*lum;
-	return float4(color, 1.0f);
+
+	return DiffuseColor.Sample(sampAni, input.Tex) * lum;
 }

--- a/SluaghEngine/Gameplay/EnemyFactory.cpp
+++ b/SluaghEngine/Gameplay/EnemyFactory.cpp
@@ -107,7 +107,7 @@ void EnemyFactory::CreateEnemies(const EnemyCreationStruct &descriptions, GameBl
 			{
 				//Move up
 				createdEnemy->SetZPosition(1.5f);
-				CoreInit::managers.transformManager->Move(createdEnemy->GetEntity(), DirectX::XMFLOAT3{ 0, 1.5f, 0 });
+				CoreInit::managers.transformManager->Move(createdEnemy->GetEntity(), DirectX::XMFLOAT3{ 0, 0.8f, 0 });
 
 				//Insert entity for sword here.
 				auto swordEntity = CoreInit::managers.entityManager->Create();

--- a/SluaghEngine/Gameplay/TutorialState.cpp
+++ b/SluaghEngine/Gameplay/TutorialState.cpp
@@ -18,6 +18,12 @@ SE::Gameplay::TutorialState::TutorialState()
 	room->Load();
 	room->RenderRoom(true);
 
+	subSystems.devConsole->AddCommand([this](DevConsole::IConsole* backend, int argc, char** argv) {
+	
+		scriptToRun = &TutorialState::SpawnaGlastigScript;
+	
+	}, "skip", "Skips the tutorial");
+
 	Skill skills[3];
 
 	skills[0].skillDamage = 10;
@@ -900,7 +906,7 @@ void SE::Gameplay::TutorialState::SpawnaNuckelaveeScript(float dt)
 	Core::Entity nuck;
 	Core::Entity nuckLight;
 	nuck = managers.entityManager->Create();
-	managers.transformManager->Create(nuck, { 16.5f, 0.0f, 10.5f }, { 0, -XM_PIDIV2,0 });
+	managers.transformManager->Create(nuck, { 16.5f, 0.9f, 10.5f }, { 0, -XM_PIDIV2,0 });
 	Core::IAnimationManager::CreateInfo aci;
 	aci.mesh = "Nuckelavee.mesh";
 	aci.skeleton = "Nuckelavee.skel";
@@ -932,7 +938,7 @@ void SE::Gameplay::TutorialState::SpawnaNuckelaveeScript(float dt)
 	managers.textManager->ToggleRenderableText(nuck, true);
 
 	Utilz::GUID anims[] = { "BottomIdleAnim_MCModell.anim","TopIdleAnim_MCModell.anim" };
-	managers.animationManager->Start(nuck, anims, 1, 7, Core::AnimationFlags::LOOP | Core::AnimationFlags::BLENDTO);
+	managers.animationManager->Start(nuck, anims, 2, 7, Core::AnimationFlags::LOOP | Core::AnimationFlags::BLENDTO);
 	managers.eventManager->SetLifetime(nuck, 12.0f);
 
 	managers.eventManager->RegisterTriggerEvent("OnDeath", [this, nuckLight](Core::Entity ent) {
@@ -1011,7 +1017,7 @@ void SE::Gameplay::TutorialState::GåTillSluaghSvartScript(float dt)
 	managers.transformManager->Create(sluagh, { 0.0f,-0.4f, 1.0f }, {0, -XM_PI,0});
 	managers.animationManager->CreateAnimatedObject(sluagh, aci);
 	managers.animationManager->ToggleVisible(sluagh, true);
-	Utilz::GUID anims[] = { "TopAttackAnim_MCModell.anim","BottomIdleAnim_MCModell.anim" };
+	Utilz::GUID anims[] = { "TopSwordAttackAnim_MCModell.anim","BottomIdleAnim_MCModell.anim" };
 	managers.animationManager->Start(sluagh, anims, 2, 2, Core::AnimationFlags::IMMEDIATE);
 
 


### PR DESCRIPTION
- Issue #1181 was caused due to only using animations for the lower body
- Issue #1182 was caused due to loading an old attack animation
- Issue #1089 only required adjustments in the Move function for the Nuckelavee in EnemyFactory