### PR TITLE
Issue 1204 win state

### DIFF
--- a/SluaghEngine/Build/Asset/Shaders/Pixel/SimpleLightTransparentPS.hlsl
+++ b/SluaghEngine/Build/Asset/Shaders/Pixel/SimpleLightTransparentPS.hlsl
@@ -1,0 +1,123 @@
+Texture2D DiffuseColor : register(t0);
+
+Texture2D NormalMap : register(t1);
+
+TextureCube ShadowMap : register(t2);
+
+SamplerState sampAni : register(s0);
+SamplerState sampPoint : register(s1);
+
+
+struct Light
+{
+	float4 colour;
+	float4 pos;
+};
+
+cbuffer LightDataBuffer : register(b0)
+{
+	uint4 nrOfLights; //x-component for number, y-component for which light is casting shadow.
+	Light pointLights[64];
+};
+
+cbuffer CameraPos : register(b1)
+{
+	float3 camUpVector;
+	float pad;
+	float3 eyePos;
+	float pad2;
+};
+
+cbuffer MaterialAttributes : register(b2)
+{
+	float4 diffuse;
+	float4 ambient;
+	float4 specular;
+};
+
+cbuffer LightViewProj : register(b3)
+{
+	float4x4 lViewProj;
+}
+
+cbuffer BloomProperties : register(b4)
+{
+	float BLOOM_BASE_MULTIPLIER;
+	float BLOOM_FADE_EXPONENT;
+	float BLOOM_ADDITIVE_COLOR_STRENGTH_MULTIPLIER;
+	float BLOOM_AT;
+};
+
+struct PS_IN
+{
+	float4 Pos : SV_POSITION;
+	float4 PosInW : WORLDPOS;
+	float4 NormalInW : NORMALINW;
+	float4 BinormalInW : BINORMALINW;
+	float4 TangentInW : TANGENTINW;
+	float2 Tex : TEXCOORD;
+};
+
+struct PS_OUT
+{
+	float4 backBuffer: SV_TARGET0;
+	float4 bloomBuffer: SV_TARGET1;
+};
+
+PS_OUT PS_main(PS_IN input) : SV_TARGET
+{
+	float attenuation = 1.0f;
+	float3 light = float3(0.0, 0.0, 0.0);
+	float shadowFactor = 1.0f;
+	float distance;
+	float specPower = specular.w;
+	float4 textureColor = DiffuseColor.Sample(sampAni, input.Tex);
+	
+	float3 diffuseContribution = float3(0.0f, 0.0f, 0.0f);
+	float3 specularContribution = float3(0.0f, 0.0f, 0.0f);
+	
+	for (int i = 0; i < nrOfLights.x; i++)
+	{
+		light = pointLights[i].pos.xyz - input.PosInW;
+		distance = length(light);
+		if(distance < pointLights[i].pos.w)
+		{
+			
+			light /= distance;
+			float normalDotLight = saturate(dot(input.NormalInW.xyz, light));
+			if(normalDotLight > 0.0f)
+			{
+				float divby = (distance / pointLights[i].pos.w) + 1.0f;
+				float intensity = pointLights[i].colour.w;
+				attenuation = (intensity / (divby * divby)) - intensity / 4;
+				
+			
+				if (i == nrOfLights.y)
+				{
+					float3 sampVec = normalize(input.PosInW - pointLights[i].pos.xyz);
+					float mapDepth = ShadowMap.Sample(sampAni, sampVec).r;
+					float ndist = distance / pointLights[i].pos.w;
+					if (mapDepth + 0.002f < distance / pointLights[i].pos.w)
+						shadowFactor = ndist;
+				}
+			
+				//Calculate specular term
+				float3 V = eyePos.xyz - input.PosInW.xyz;
+				float3 H = normalize(light + V);
+				float3 power = pow(saturate(dot(input.NormalInW.xyz, H)), specPower);
+				float3 colour = pointLights[i].colour.xyz * specular.xyz;
+				specularContribution += power * colour * normalDotLight * shadowFactor;
+				diffuseContribution += attenuation * normalDotLight * pointLights[i].colour.xyz * shadowFactor;
+			}
+		}
+	}
+
+	PS_OUT output;
+	output.backBuffer = saturate(float4(textureColor.rgb * ((diffuseContribution + specularContribution) + float3(0.1f, 0.1f, 0.1f)), 0.50f));
+	output.bloomBuffer = float4(0.0f, 0.0f, 0.0f, 1.0f);
+	if (output.backBuffer.r > BLOOM_AT) output.bloomBuffer.r = output.backBuffer.r * output.backBuffer.r;
+	if (output.backBuffer.g > BLOOM_AT) output.bloomBuffer.g = output.backBuffer.g * output.backBuffer.g;
+	if (output.backBuffer.b > BLOOM_AT) output.bloomBuffer.b = output.backBuffer.b * output.backBuffer.b;
+
+	return output;
+}

--- a/SluaghEngine/Core/AnimationManager.cpp
+++ b/SluaghEngine/Core/AnimationManager.cpp
@@ -805,6 +805,17 @@ void SE::Core::AnimationManager::ToggleShadow(const Entity& entity, bool on)
 	ProfileReturnVoid;
 }
 
+void SE::Core::AnimationManager::ToggleTransparency(const Entity& entity, bool on)
+{
+	StartProfile;
+	const auto exists = entityToIndex.find(entity);
+	if (exists != entityToIndex.end())
+	{
+		renderableManager->ToggleTransparency(entity, on);
+	}
+	ProfileReturnVoid;
+}
+
 void SE::Core::AnimationManager::Allocate(size_t size)
 {
 	StartProfile;

--- a/SluaghEngine/Core/AnimationManager.h
+++ b/SluaghEngine/Core/AnimationManager.h
@@ -52,6 +52,7 @@ namespace SE
 			
 			void ToggleVisible(const Entity& entity, bool visible)override;
 			void ToggleShadow(const Entity& entity, bool on) override;
+			void ToggleTransparency(const Entity& entity, bool on) override;
 
 		private:
 			/**

--- a/SluaghEngine/Core/CameraManager.cpp
+++ b/SluaghEngine/Core/CameraManager.cpp
@@ -86,8 +86,8 @@ void SE::Core::CameraManager::UpdateCamera(const CreateInfo & info)
 		cameraData.aspectRatio[currentActive.activeCamera] = info.aspectRatio;
 		cameraData.nearPlane[currentActive.activeCamera] = info.nearPlane;
 		cameraData.farPlane[currentActive.activeCamera] = info.farPlance;
-
-		initInfo.transformManager->SetAsDirty(currentActive.activeCamera);
+		if(initInfo.entityManager->Alive(cameraData.entity[currentActive.activeCamera]))
+			initInfo.transformManager->SetAsDirty(currentActive.activeCamera);
 	}
 	StopProfile;
 }

--- a/SluaghEngine/Core/EntityManager.cpp
+++ b/SluaghEngine/Core/EntityManager.cpp
@@ -74,6 +74,17 @@ void SE::Core::EntityManager::DestroyNow(const Entity& e)
 	}
 }
 
+void SE::Core::EntityManager::DestroyAll()
+{
+	for (uint32_t i = 0; i < _generationCount; ++i)
+	{
+		Entity e = (_generation[i] << Entity::ENTITY_INDEX_BITS) | i;
+		_destroyCallbacks[e.Index()](e);
+		_destroyCallbacks[e.Index()].Clear();
+		++_generation[i];
+	}
+}
+
 void SE::Core::EntityManager::RegisterDestroyCallback(const Entity & e, const Utilz::Delegate<void(const Entity&)>& callback)
 {
 	_ASSERT(_generation[e.Index()] == e.Gen());

--- a/SluaghEngine/Core/EntityManager.h
+++ b/SluaghEngine/Core/EntityManager.h
@@ -73,6 +73,8 @@ namespace SE
 			*/
 			void DestroyNow(const Entity& e)override;
 
+			void DestroyAll() override;
+
 			/**
 			* @brief    Register a destroy callback for an entity.
 			* @param[in] e The entity to bind to.

--- a/SluaghEngine/Core/ImGuiConsole.cpp
+++ b/SluaghEngine/Core/ImGuiConsole.cpp
@@ -118,8 +118,8 @@ void SE::Core::ImGuiConsole::Frame()
 	}
 
 	// Demonstrate keeping auto focus on the input box
-	//if (ImGui::IsItemHovered() || (ImGui::IsRootWindowOrAnyChildFocused() && !ImGui::IsAnyItemActive() && !ImGui::IsMouseClicked(0)))
-	//	ImGui::SetKeyboardFocusHere(-1); // Auto focus previous widget
+	if (ImGui::IsItemHovered() || (ImGui::IsRootWindowOrAnyChildFocused() && !ImGui::IsAnyItemActive() && !ImGui::IsMouseClicked(0)))
+		ImGui::SetKeyboardFocusHere(-1); // Auto focus previous widget
 	ImGui::End();
 	
 	ProfileReturnVoid;

--- a/SluaghEngine/Gameplay/Game.cpp
+++ b/SluaghEngine/Gameplay/Game.cpp
@@ -2,6 +2,7 @@
 #include "CoreInit.h"
 #include <Profiler.h>
 #include <TutorialState.h>
+#include "WinState.h"
 
 void SE::Gameplay::Game::Initiate(Core::IEngine* engine)
 {
@@ -77,9 +78,9 @@ void SE::Gameplay::Game::Run()
 			if (currentState == SE::Gameplay::IGameState::State::PLAY_STATE)
 			{
 				CoreInit::subSystems.window->StopRecording();
-				CoreInit::engine->EndFrame();
-				return;
+				
 			}
+
 			switch (newState)
 			{
 				case SE::Gameplay::IGameState::State::GAME_OVER_STATE:
@@ -121,9 +122,16 @@ void SE::Gameplay::Game::Run()
 					CoreInit::managers.entityManager->DestroyAll();
 					state = new TutorialState();
 					break;
+				case SE::Gameplay::IGameState::State::WIN_STATE:
+					delete state;
+					CoreInit::managers.entityManager->DestroyAll();
+					state = new WinState();
+					break;
 				case SE::Gameplay::IGameState::State::QUIT_GAME:
 					
 					running = false;
+					break;
+				default:
 					break;
 			 }
 

--- a/SluaghEngine/Gameplay/Game.cpp
+++ b/SluaghEngine/Gameplay/Game.cpp
@@ -87,6 +87,7 @@ void SE::Gameplay::Game::Run()
 					/*if (currentState == SE::Gameplay::IGameState::State::PLAY_STATE || currentState == SE::Gameplay::IGameState::State::CHARACTER_CREATION_STATE)
 						CoreInit::subSystems.window->StopRecording();*/
 					delete state;
+					CoreInit::managers.entityManager->DestroyAll();
 					state = new SE::Gameplay::PlayState(CoreInit::subSystems.window, engine, data);
 					break;
 				}
@@ -95,6 +96,7 @@ void SE::Gameplay::Game::Run()
 					/*if (currentState == SE::Gameplay::IGameState::State::PLAY_STATE || currentState == SE::Gameplay::IGameState::State::CHARACTER_CREATION_STATE)
 						CoreInit::subSystems.window->StopRecording();*/
 					delete state;
+					CoreInit::managers.entityManager->DestroyAll();
 					state = new SE::Gameplay::MainMenuState(CoreInit::subSystems.window);
 					break;
 				}
@@ -102,18 +104,21 @@ void SE::Gameplay::Game::Run()
 				{
 					/*CoreInit::subSystems.window->StartRecording();*/
 					delete state;
+					CoreInit::managers.entityManager->DestroyAll();
 					state = new SE::Gameplay::CharacterCreationState(CoreInit::subSystems.window);
 					break;
 				}
 				case SE::Gameplay::IGameState::State::PLAY_STATE:
 				{
 					delete state;
+					CoreInit::managers.entityManager->DestroyAll();
 					state = new SE::Gameplay::PlayState(CoreInit::subSystems.window, engine, data);
 					CoreInit::subSystems.window->UpdateTime();
 					break;
 				}
 				case SE::Gameplay::IGameState::State::TUTORIAL_STATE:
 					delete state;
+					CoreInit::managers.entityManager->DestroyAll();
 					state = new TutorialState();
 					break;
 				case SE::Gameplay::IGameState::State::QUIT_GAME:

--- a/SluaghEngine/Gameplay/Gameplay.vcxproj
+++ b/SluaghEngine/Gameplay/Gameplay.vcxproj
@@ -99,6 +99,7 @@
     <ClCompile Include="TransistionToRoomLeaf.cpp" />
     <ClCompile Include="TutorialState.cpp" />
     <ClCompile Include="WhileChannelingLeaf.cpp" />
+    <ClCompile Include="WinState.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\includes\Gameplay\AddTimeToAttackCooldownLeaf.h" />
@@ -192,6 +193,7 @@
     <ClInclude Include="..\includes\Gameplay\TransistionToRoomLeaf.h" />
     <ClInclude Include="..\includes\Gameplay\TutorialState.h" />
     <ClInclude Include="..\includes\Gameplay\WhileChannelingLeaf.h" />
+    <ClInclude Include="..\includes\Gameplay\WinState.h" />
     <ClInclude Include="Game.h" />
     <ClInclude Include="CoreInit.h" />
   </ItemGroup>

--- a/SluaghEngine/Gameplay/Gameplay.vcxproj.filters
+++ b/SluaghEngine/Gameplay/Gameplay.vcxproj.filters
@@ -695,11 +695,11 @@
     <ClInclude Include="..\includes\Gameplay\PerkFactory.h">
       <Filter>Header Files\Perks</Filter>
     </ClInclude>
-    <ClInclude Include="..\includes\Gameplay\WinState.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\includes\Gameplay\OptionState.h">
       <Filter>Header Files\IGameState\OptionState</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\Gameplay\WinState.h">
+      <Filter>Header Files\IGameState</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/SluaghEngine/Gameplay/Gameplay.vcxproj.filters
+++ b/SluaghEngine/Gameplay/Gameplay.vcxproj.filters
@@ -393,6 +393,9 @@
     <ClCompile Include="PerkFactory.cpp">
       <Filter>Source Files\Perks</Filter>
     </ClCompile>
+    <ClCompile Include="WinState.cpp">
+      <Filter>Source Files\IGameState</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\includes\Gameplay\EventStructs.h">
@@ -682,6 +685,9 @@
     </ClInclude>
     <ClInclude Include="..\includes\Gameplay\PerkFactory.h">
       <Filter>Header Files\Perks</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\Gameplay\WinState.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/SluaghEngine/Gameplay/PlayState.cpp
+++ b/SluaghEngine/Gameplay/PlayState.cpp
@@ -125,6 +125,8 @@ PlayState::~PlayState()
 	StartProfile;
 	CoreInit::subSystems.devConsole->RemoveCommand("tgm");
 	CoreInit::subSystems.devConsole->RemoveCommand("setspeed");
+	CoreInit::subSystems.devConsole->RemoveCommand("killself");
+	
 	delete projectileManager;
 	delete player;
 	//delete currentRoom;
@@ -693,6 +695,11 @@ void SE::Gameplay::PlayState::InitializeOther()
 		this->player->SetSpeed(speed);
 
 	}, "setspeed", "setspeed <value>");
+
+	CoreInit::subSystems.devConsole->AddCommand([this](DevConsole::IConsole* back, int argc, char** argv) {
+		this->player->Suicide();
+
+	}, "killself", "Kills the player character");
 	
 	ProfileReturnVoid;
 }
@@ -881,7 +888,7 @@ IGameState::State PlayState::Update(void*& passableInfo)
 	UpdateHUD(dt);
 
 	if (!player->IsAlive())
-		returnValue = State::GAME_OVER_STATE;
+		returnValue = State::WIN_STATE;
 
 	ProfileReturn(returnValue);
 

--- a/SluaghEngine/Gameplay/PlayState.cpp
+++ b/SluaghEngine/Gameplay/PlayState.cpp
@@ -889,6 +889,16 @@ IGameState::State PlayState::Update(void*& passableInfo)
 
 	if (!player->IsAlive())
 		returnValue = State::WIN_STATE;
+	
+	if(sluaghDoorsOpen)
+	{
+		auto sluaghRoom = dynamic_cast<SluaghRoom*>(GetRoom(sluaghRoomX, sluaghRoomY).value());
+		if(sluaghRoom)
+		{
+			if (sluaghRoom->GetSluagh()->GetSluagh()->GetHealth() <= 0.0f)
+				returnValue = State::WIN_STATE;
+		}
+	}
 
 	ProfileReturn(returnValue);
 

--- a/SluaghEngine/Gameplay/PlayState.cpp
+++ b/SluaghEngine/Gameplay/PlayState.cpp
@@ -627,8 +627,9 @@ void SE::Gameplay::PlayState::InitializeOther()
 	//Setup camera to the correct perspective and bind it to the players position
 	Core::ICameraManager::CreateInfo cInfo;
 	cInfo.aspectRatio = CoreInit::subSystems.optionsHandler->GetOptionDouble("Camera", "aspectRatio", (1280.0f / 720.0f));
-	cam = CoreInit::managers.cameraManager->GetActive();
-	CoreInit::managers.cameraManager->UpdateCamera(cam, cInfo);
+	cam = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.cameraManager->Create(cam, cInfo);
+	CoreInit::managers.cameraManager->SetActive(cam);
 
 	float cameraRotationX = DirectX::XM_PI / 3;
 	float cameraRotationY = DirectX::XM_PI / 3;

--- a/SluaghEngine/Gameplay/PlayerUnit.cpp
+++ b/SluaghEngine/Gameplay/PlayerUnit.cpp
@@ -312,6 +312,11 @@ void SE::Gameplay::PlayerUnit::SetSpeed(float speed)
 	this->newStat.movementSpeed = speed;
 }
 
+void SE::Gameplay::PlayerUnit::Suicide()
+{
+	this->health = -100.0f;
+}
+
 void SE::Gameplay::PlayerUnit::UpdatePlayerRotation(float camAngleX, float camAngleY)
 {
 	StartProfile;

--- a/SluaghEngine/Gameplay/TutorialState.cpp
+++ b/SluaghEngine/Gameplay/TutorialState.cpp
@@ -106,8 +106,10 @@ SE::Gameplay::TutorialState::TutorialState()
 	Core::Entity cam;
 	Core::ICameraManager::CreateInfo cInfo;
 	cInfo.aspectRatio = CoreInit::subSystems.optionsHandler->GetOptionDouble("Camera", "aspectRatio", (1280.0f / 720.0f));
-	cam = managers.cameraManager->GetActive();
-	managers.cameraManager->UpdateCamera(cam, cInfo);
+	cam = managers.entityManager->Create();
+	managers.cameraManager->Create(cam, cInfo);
+	managers.cameraManager->SetActive(cam);
+	
 
 	float cameraRotationX = DirectX::XM_PI / 3;
 	float cameraRotationY = DirectX::XM_PI / 3;

--- a/SluaghEngine/Gameplay/WinState.cpp
+++ b/SluaghEngine/Gameplay/WinState.cpp
@@ -45,11 +45,13 @@ SE::Gameplay::WinState::WinState()
 	Core::IAnimationManager::CreateInfo deadcinfo2;
 	deadcinfo2.mesh = "MCModell.mesh";
 	deadcinfo2.skeleton = "MCModell.skel";
-	Utilz::GUID anims2[] = { "DeathAnim_MCModell.anim" };
+	Utilz::GUID anims2[] = { "DeathAnim_MCModell.anim","TopIdleAnim_MCModell.anim", "BottomIdleAnim_MCModell.anim" };
 	deadcinfo2.animations = anims2;
 	man.animationManager->CreateAnimatedObject(sluaghSoul, deadcinfo2);
 	man.animationManager->Start(sluaghSoul, anims2, 1, 2.0f, Core::AnimationFlags::IMMEDIATE);
-	
+	man.animationManager->ToggleTransparency(sluaghSoul, true);
+	man.animationManager->ToggleVisible(sluaghSoul, true);
+	man.transformManager->SetPosition(sluaghSoul, { 300.0f, 0.0f, 0.0f });
 
 	auto l = man.entityManager->Create();
 	Core::ILightManager::CreateInfo d;
@@ -72,6 +74,7 @@ SE::Gameplay::WinState::WinState()
 	stateToReturn = State::WIN_STATE;
 	timer.Tick();
 	totTime = 0.0f;
+	hack = true;
 }
 
 SE::Gameplay::WinState::~WinState()
@@ -84,10 +87,18 @@ SE::Gameplay::IGameState::State SE::Gameplay::WinState::Update(void*&)
 	timer.Tick();
 	float dt = timer.GetDelta<std::ratio<1,1>>();
 	totTime += dt;
+	
 	if(totTime > 2.0f)
 	{
-		man.animationManager->ToggleVisible(sluaghSoul, true);
+		if(hack)
+		{
+			man.transformManager->SetPosition(sluaghSoul, man.transformManager->GetPosition(deadSluagh));
+			hack = false;
+			Utilz::GUID an[] = { "TopIdleAnim_MCModell.anim", "BottomIdleAnim_MCModell.anim" };
+			man.animationManager->Start(sluaghSoul, an, 2, 5.0f, Core::AnimationFlags::BLENDTO | Core::AnimationFlags::LOOP);
+		}
 		man.transformManager->Move(sluaghSoul, DirectX::XMFLOAT3(0.0f, 0.5f * dt, 0.0f));
+
 	}
 	if (sys.window->ButtonPressed(Window::KeyReturn))
 		return State::CHARACTER_CREATION_STATE;

--- a/SluaghEngine/Gameplay/WinState.cpp
+++ b/SluaghEngine/Gameplay/WinState.cpp
@@ -13,17 +13,43 @@ SE::Gameplay::WinState::WinState()
 	camc.aspectRatio = sys.optionsHandler->GetOptionDouble("Camera", "aspectRatio", 1280.0f / 720.0f);
 	man.cameraManager->Create(cam, camc);
 	man.cameraManager->SetActive(cam);
-	man.transformManager->SetPosition(cam, { 0.0f, 0.0f, -5.0f });
+	man.transformManager->SetPosition(cam, { 0.0f, 0.0f, 0.0f });
 
 	deadSluagh = man.entityManager->Create();
+	man.transformManager->Create(deadSluagh, { 0.0f, 0.0f, 2.0f }, {0.0f, 3.14f, 0.0f});
+	Core::IMaterialManager::CreateInfo info;
+	auto shader = Utilz::GUID("SimpleLightPS.hlsl");
+	auto material = Utilz::GUID("Slaughplane.mat");
+	info.shader = shader;
+	info.materialFile = material;
+	man.materialManager->Create(deadSluagh, info);
+
 	Core::IAnimationManager::CreateInfo deadcinfo;
 	deadcinfo.mesh = "MCModell.mesh";
 	deadcinfo.skeleton = "MCModell.skel";
 	Utilz::GUID anims[] = { "DeathAnim_MCModell.anim" };
 	deadcinfo.animations = anims;
 	man.animationManager->CreateAnimatedObject(deadSluagh, deadcinfo);
-	man.animationManager->Start(deadSluagh, anims, 1, 1.0f, Core::AnimationFlags::IMMEDIATE);
+	man.animationManager->Start(deadSluagh, anims, 1, 2.0f, Core::AnimationFlags::IMMEDIATE);
 	man.animationManager->ToggleVisible(deadSluagh, true);
+
+	sluaghSoul = man.entityManager->Create();
+	man.transformManager->Create(sluaghSoul, { 0.0f, 0.0f, 2.0f }, { 0.0f, 3.14f, 0.0f });
+	Core::IMaterialManager::CreateInfo info2;
+	auto shader2 = Utilz::GUID("SimpleLightTransparentPS.hlsl");
+	auto material2 = Utilz::GUID("Slaughplane.mat");
+	info.shader = shader2;
+	info.materialFile = material2;
+	man.materialManager->Create(sluaghSoul, info);
+
+	Core::IAnimationManager::CreateInfo deadcinfo2;
+	deadcinfo2.mesh = "MCModell.mesh";
+	deadcinfo2.skeleton = "MCModell.skel";
+	Utilz::GUID anims2[] = { "DeathAnim_MCModell.anim" };
+	deadcinfo2.animations = anims2;
+	man.animationManager->CreateAnimatedObject(sluaghSoul, deadcinfo2);
+	man.animationManager->Start(sluaghSoul, anims2, 1, 2.0f, Core::AnimationFlags::IMMEDIATE);
+	
 
 	auto l = man.entityManager->Create();
 	Core::ILightManager::CreateInfo d;
@@ -43,6 +69,9 @@ SE::Gameplay::WinState::WinState()
 	man.textManager->ToggleRenderableText(victoryText, true);
 
 	sys.window->MapActionButton(Window::KeyReturn, Window::KeyReturn);
+	stateToReturn = State::WIN_STATE;
+	timer.Tick();
+	totTime = 0.0f;
 }
 
 SE::Gameplay::WinState::~WinState()
@@ -52,8 +81,15 @@ SE::Gameplay::WinState::~WinState()
 
 SE::Gameplay::IGameState::State SE::Gameplay::WinState::Update(void*&)
 {
-
+	timer.Tick();
+	float dt = timer.GetDelta<std::ratio<1,1>>();
+	totTime += dt;
+	if(totTime > 2.0f)
+	{
+		man.animationManager->ToggleVisible(sluaghSoul, true);
+		man.transformManager->Move(sluaghSoul, DirectX::XMFLOAT3(0.0f, 0.5f * dt, 0.0f));
+	}
 	if (sys.window->ButtonPressed(Window::KeyReturn))
 		return State::CHARACTER_CREATION_STATE;
-	return IGameState::State::WIN_STATE;
+	return stateToReturn;
 }

--- a/SluaghEngine/Gameplay/WinState.cpp
+++ b/SluaghEngine/Gameplay/WinState.cpp
@@ -48,7 +48,7 @@ SE::Gameplay::WinState::WinState()
 	Utilz::GUID anims2[] = { "DeathAnim_MCModell.anim","TopIdleAnim_MCModell.anim", "BottomIdleAnim_MCModell.anim" };
 	deadcinfo2.animations = anims2;
 	man.animationManager->CreateAnimatedObject(sluaghSoul, deadcinfo2);
-	man.animationManager->Start(sluaghSoul, anims2, 1, 2.0f, Core::AnimationFlags::IMMEDIATE);
+	man.animationManager->Start(sluaghSoul, anims2, 1, 2.0f, Core::AnimationFlags::BLENDTOANDBACK);
 	man.animationManager->ToggleTransparency(sluaghSoul, true);
 	man.animationManager->ToggleVisible(sluaghSoul, true);
 	man.transformManager->SetPosition(sluaghSoul, { 300.0f, 0.0f, 0.0f });
@@ -75,6 +75,7 @@ SE::Gameplay::WinState::WinState()
 	timer.Tick();
 	totTime = 0.0f;
 	hack = true;
+	hack2 = true;
 }
 
 SE::Gameplay::WinState::~WinState()
@@ -90,12 +91,18 @@ SE::Gameplay::IGameState::State SE::Gameplay::WinState::Update(void*&)
 	
 	if(totTime > 2.0f)
 	{
+			
 		if(hack)
 		{
 			man.transformManager->SetPosition(sluaghSoul, man.transformManager->GetPosition(deadSluagh));
 			hack = false;
-			Utilz::GUID an[] = { "TopIdleAnim_MCModell.anim", "BottomIdleAnim_MCModell.anim" };
-			man.animationManager->Start(sluaghSoul, an, 2, 5.0f, Core::AnimationFlags::BLENDTO | Core::AnimationFlags::LOOP);
+			
+		}
+		if (totTime > 4.0f && hack2)
+		{
+			//Utilz::GUID an[] = { "TopIdleAnim_MCModell.anim", "BottomIdleAnim_MCModell.anim" };
+			//man.animationManager->Start(sluaghSoul, an, 2, 5.0f, Core::AnimationFlags::BLENDTO | Core::AnimationFlags::LOOP);
+			hack2 = false;
 		}
 		man.transformManager->Move(sluaghSoul, DirectX::XMFLOAT3(0.0f, 0.5f * dt, 0.0f));
 

--- a/SluaghEngine/Gameplay/WinState.cpp
+++ b/SluaghEngine/Gameplay/WinState.cpp
@@ -1,0 +1,59 @@
+#include "WinState.h"
+#include "CoreInit.h"
+static SE::Core::IEngine::ManagerWrapper man;
+static SE::Core::IEngine::Subsystems sys;
+SE::Gameplay::WinState::WinState()
+{
+	man = CoreInit::managers;
+	sys = CoreInit::subSystems;
+	
+
+	cam = man.entityManager->Create();
+	Core::ICameraManager::CreateInfo camc;
+	camc.aspectRatio = sys.optionsHandler->GetOptionDouble("Camera", "aspectRatio", 1280.0f / 720.0f);
+	man.cameraManager->Create(cam, camc);
+	man.cameraManager->SetActive(cam);
+	man.transformManager->SetPosition(cam, { 0.0f, 0.0f, -5.0f });
+
+	deadSluagh = man.entityManager->Create();
+	Core::IAnimationManager::CreateInfo deadcinfo;
+	deadcinfo.mesh = "MCModell.mesh";
+	deadcinfo.skeleton = "MCModell.skel";
+	Utilz::GUID anims[] = { "DeathAnim_MCModell.anim" };
+	deadcinfo.animations = anims;
+	man.animationManager->CreateAnimatedObject(deadSluagh, deadcinfo);
+	man.animationManager->Start(deadSluagh, anims, 1, 1.0f, Core::AnimationFlags::IMMEDIATE);
+	man.animationManager->ToggleVisible(deadSluagh, true);
+
+	auto l = man.entityManager->Create();
+	Core::ILightManager::CreateInfo d;
+	d.radius = 100.0f;
+	d.pos = { 0.0f, 3.0f, 0.0f };
+	d.color = { 1, 1, 1 };
+	man.lightManager->Create(l, d);
+	man.lightManager->ToggleLight(l, true);
+
+	victoryText = man.entityManager->Create();
+	Core::ITextManager::CreateInfo textci;
+	textci.font = "Knights.spritefont";
+	textci.info.text = L"        DU HAR BESEGRAT DEN ONDE SLUAGHEN\nMÅ HEDER OCH ÄRA SKÖLJA ÖVER DIG I STORA MÅTT";
+	textci.info.scale = { 0.5f, 0.5f };
+	man.textManager->Create(victoryText, textci);
+	man.textManager->SetTextPos(victoryText, sys.window->Width() / 2 - 505, sys.window->Height() / 2 + 200);
+	man.textManager->ToggleRenderableText(victoryText, true);
+
+	sys.window->MapActionButton(Window::KeyReturn, Window::KeyReturn);
+}
+
+SE::Gameplay::WinState::~WinState()
+{
+	
+}
+
+SE::Gameplay::IGameState::State SE::Gameplay::WinState::Update(void*&)
+{
+
+	if (sys.window->ButtonPressed(Window::KeyReturn))
+		return State::CHARACTER_CREATION_STATE;
+	return IGameState::State::WIN_STATE;
+}

--- a/SluaghEngine/Gameplay/WinState.cpp
+++ b/SluaghEngine/Gameplay/WinState.cpp
@@ -48,7 +48,7 @@ SE::Gameplay::WinState::WinState()
 	Utilz::GUID anims2[] = { "DeathAnim_MCModell.anim","TopIdleAnim_MCModell.anim", "BottomIdleAnim_MCModell.anim" };
 	deadcinfo2.animations = anims2;
 	man.animationManager->CreateAnimatedObject(sluaghSoul, deadcinfo2);
-	man.animationManager->Start(sluaghSoul, anims2, 1, 2.0f, Core::AnimationFlags::BLENDTOANDBACK);
+	man.animationManager->Start(sluaghSoul, anims2, 1, 2.0f, Core::AnimationFlags::IMMEDIATE);
 	man.animationManager->ToggleTransparency(sluaghSoul, true);
 	man.animationManager->ToggleVisible(sluaghSoul, true);
 	man.transformManager->SetPosition(sluaghSoul, { 300.0f, 0.0f, 0.0f });
@@ -70,12 +70,19 @@ SE::Gameplay::WinState::WinState()
 	man.textManager->SetTextPos(victoryText, sys.window->Width() / 2 - 505, sys.window->Height() / 2 + 200);
 	man.textManager->ToggleRenderableText(victoryText, true);
 
+	infoText = man.entityManager->Create();
+	textci.info.text = L"TRYCK PÅ RETUR FÖR ATT GÅ TILLBAKA TILL MENYN";
+	textci.info.scale = { 0.25f, 0.25f };
+	textci.info.colour = { 0.2f,0.8f,0.2f,1.0f };
+	man.textManager->Create(infoText, textci);
+	man.textManager->SetTextPos(infoText, sys.window->Width() / 2 - 250, sys.window->Height() / 2 + 320);
+	man.textManager->ToggleRenderableText(infoText, true);
+
 	sys.window->MapActionButton(Window::KeyReturn, Window::KeyReturn);
 	stateToReturn = State::WIN_STATE;
 	timer.Tick();
 	totTime = 0.0f;
 	hack = true;
-	hack2 = true;
 }
 
 SE::Gameplay::WinState::~WinState()
@@ -95,15 +102,11 @@ SE::Gameplay::IGameState::State SE::Gameplay::WinState::Update(void*&)
 		if(hack)
 		{
 			man.transformManager->SetPosition(sluaghSoul, man.transformManager->GetPosition(deadSluagh));
-			hack = false;
-			
+			Utilz::GUID an[] = { "TopIdleAnim_MCModell.anim", "BottomIdleAnim_MCModell.anim" };
+			man.animationManager->Start(sluaghSoul, an, 2, 5.0f, Core::AnimationFlags::BLENDTO | Core::AnimationFlags::LOOP);
+			hack = false;			
 		}
-		if (totTime > 4.0f && hack2)
-		{
-			//Utilz::GUID an[] = { "TopIdleAnim_MCModell.anim", "BottomIdleAnim_MCModell.anim" };
-			//man.animationManager->Start(sluaghSoul, an, 2, 5.0f, Core::AnimationFlags::BLENDTO | Core::AnimationFlags::LOOP);
-			hack2 = false;
-		}
+
 		man.transformManager->Move(sluaghSoul, DirectX::XMFLOAT3(0.0f, 0.5f * dt, 0.0f));
 
 	}

--- a/SluaghEngine/includes/Core/IAnimationManager.h
+++ b/SluaghEngine/includes/Core/IAnimationManager.h
@@ -106,6 +106,7 @@ namespace SE
 
 			virtual void ToggleVisible(const Entity& entity, bool visible) = 0;
 			virtual void ToggleShadow(const Entity& entity, bool on) = 0;
+			virtual void ToggleTransparency(const Entity& entity, bool on) = 0;
 
 		protected:
 			IAnimationManager() {};

--- a/SluaghEngine/includes/Core/IEntityManager.h
+++ b/SluaghEngine/includes/Core/IEntityManager.h
@@ -62,6 +62,11 @@ namespace SE
 			*/
 			virtual void DestroyNow(const Entity& e) = 0;
 
+			/*
+			 *@brief Destroys all entities.
+			 */
+			virtual void DestroyAll() = 0;
+
 			/**
 			* @brief    Register a destroy callback for an entity.
 			* @param[in] e The entity to bind to.

--- a/SluaghEngine/includes/Gameplay/IGameState.h
+++ b/SluaghEngine/includes/Gameplay/IGameState.h
@@ -46,7 +46,8 @@ namespace SE
 				CHARACTER_CREATION_STATE = 3,
 				PAUSE_STATE = 4,
 				TUTORIAL_STATE = 5,
-				QUIT_GAME
+				WIN_STATE = 6,
+				QUIT_GAME = 7
 			};
 
 			 

--- a/SluaghEngine/includes/Gameplay/PlayerUnit.h
+++ b/SluaghEngine/includes/Gameplay/PlayerUnit.h
@@ -88,6 +88,7 @@ namespace SE
 			//Cheats
 			void SetGodMode(bool on);
 			void SetSpeed(float speed);
+			void Suicide();
 
 			std::vector<DamageEvent>& GetDamageEvents();
 			std::vector<HealingEvent>& GetHealingEvents();

--- a/SluaghEngine/includes/Gameplay/SluaghRoom.h
+++ b/SluaghEngine/includes/Gameplay/SluaghRoom.h
@@ -15,6 +15,7 @@ namespace SE
 			~SluaghRoom() override;
 			void Update(float dt, float playerX, float playerY) override;
 			void InitSluagh();
+			Sluagh* GetSluagh() const { return theSluagh; };
 		private:
 			bool ProjectileAgainstEnemies(Projectile& projectile) override;
 			ProjectileManager* projectileManagers;

--- a/SluaghEngine/includes/Gameplay/WinState.h
+++ b/SluaghEngine/includes/Gameplay/WinState.h
@@ -1,6 +1,7 @@
 #ifndef SE_GAMEPLAY_WIN_STATE_H_
 #define SE_GAMEPLAY_WIN_STATE_H_
 #include "IGameState.h"
+#include "Utilz/Timer.h"
 
 namespace SE::Gameplay
 {
@@ -15,10 +16,14 @@ namespace SE::Gameplay
 	private:
 		Core::Entity cam;
 		Core::Entity deadSluagh;
+		Core::Entity sluaghSoul;
 		Core::Entity victoriousScot;
 		Core::Entity victoryText;
 		Core::Entity quitButton;
 		Core::Entity newCharacterButton;
+		Utilz::Timer timer;
+		State stateToReturn;
+		float totTime;
 	};
 }
 

--- a/SluaghEngine/includes/Gameplay/WinState.h
+++ b/SluaghEngine/includes/Gameplay/WinState.h
@@ -1,0 +1,26 @@
+#ifndef SE_GAMEPLAY_WIN_STATE_H_
+#define SE_GAMEPLAY_WIN_STATE_H_
+#include "IGameState.h"
+
+namespace SE::Gameplay
+{
+	class WinState : public IGameState
+	{
+	public:
+		WinState();
+		~WinState();
+
+		State Update(void*&)override;
+
+	private:
+		Core::Entity cam;
+		Core::Entity deadSluagh;
+		Core::Entity victoriousScot;
+		Core::Entity victoryText;
+		Core::Entity quitButton;
+		Core::Entity newCharacterButton;
+	};
+}
+
+
+#endif

--- a/SluaghEngine/includes/Gameplay/WinState.h
+++ b/SluaghEngine/includes/Gameplay/WinState.h
@@ -17,15 +17,12 @@ namespace SE::Gameplay
 		Core::Entity cam;
 		Core::Entity deadSluagh;
 		Core::Entity sluaghSoul;
-		Core::Entity victoriousScot;
 		Core::Entity victoryText;
-		Core::Entity quitButton;
-		Core::Entity newCharacterButton;
+		Core::Entity infoText;
 		Utilz::Timer timer;
 		State stateToReturn;
 		float totTime;
 		bool hack;
-		bool hack2;
 	};
 }
 

--- a/SluaghEngine/includes/Gameplay/WinState.h
+++ b/SluaghEngine/includes/Gameplay/WinState.h
@@ -25,6 +25,7 @@ namespace SE::Gameplay
 		State stateToReturn;
 		float totTime;
 		bool hack;
+		bool hack2;
 	};
 }
 

--- a/SluaghEngine/includes/Gameplay/WinState.h
+++ b/SluaghEngine/includes/Gameplay/WinState.h
@@ -24,6 +24,7 @@ namespace SE::Gameplay
 		Utilz::Timer timer;
 		State stateToReturn;
 		float totTime;
+		bool hack;
 	};
 }
 


### PR DESCRIPTION

Connected to issue #1204

Additions:
* Added win screen for when the sluagh is killed.
* The win screen is also used on player death as a placeholder.
* Added a command to kill the player in the console
* All entities are destroyed between state changes
* Added a new shader that is only used for the winscreen. 

Changes: 
* default camera is no longer used since all entities are destroyed when the state changes.


- [x] I have a local backup of Latest Build/Asset.
- [x] I have added new assets to Latest Build/Asset.
- [x] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
- [x] I have merged my branch with master and it works as expected.
