### PR TITLE
Issue 1220 item vis

### DIFF
--- a/SluaghEngine/Core/DataManager.cpp
+++ b/SluaghEngine/Core/DataManager.cpp
@@ -95,6 +95,7 @@ std::ifstream& operator>>(std::ifstream& in, std::pair<const SE::Utilz::GUID, SE
 		char* buff = new char[len];
 		in.read(buff, len);
 		value.second = std::string(buff, len);
+		delete[] buff;
 		break;
 	}
 	case 5:

--- a/SluaghEngine/Core/EventManager.cpp
+++ b/SluaghEngine/Core/EventManager.cpp
@@ -220,7 +220,7 @@ void SE::Core::EventManager::Frame(Utilz::TimeCluster * timer)
 		for (auto& ent : triggerEvents[_event].entitesRegistered)
 			triggerEvents[_event].callback(ent);
 	}
-
+	eventsToTrigger.clear();
 
 
 	timer->Stop("EventManager");

--- a/SluaghEngine/Core/MaterialManager.cpp
+++ b/SluaghEngine/Core/MaterialManager.cpp
@@ -175,7 +175,7 @@ void SE::Core::MaterialManager::Create(const Entity & entity, const CreateInfo& 
 
 		auto res = initInfo.resourceHandler->LoadResource(info.materialFile, materialCallbacks, ResourceHandler::LoadFlags::LOAD_FOR_RAM);
 		if (res < 0)
-			return ResourceHandler::InvokeReturn::FAIL;
+			return ResourceHandler::InvokeReturn::SEMI_FAIL;
 
 
 		ResourceHandler::Callbacks textureCallbacks;
@@ -195,7 +195,7 @@ void SE::Core::MaterialManager::Create(const Entity & entity, const CreateInfo& 
 		}
 
 		if (!toUpdate.push({ guid, info.materialFile, mdata, entity }))
-			return ResourceHandler::InvokeReturn::FAIL;
+			return ResourceHandler::InvokeReturn::SEMI_FAIL;
 
 		return ResourceHandler::InvokeReturn::SUCCESS;
 	};

--- a/SluaghEngine/Gameplay/Consumable.cpp
+++ b/SluaghEngine/Gameplay/Consumable.cpp
@@ -1,0 +1,122 @@
+#include <Consumable.h>
+#include "CoreInit.h"
+#include <Items.h>
+#include <array>
+
+struct ConsumableInfo
+{
+	SE::Utilz::GUID icon;
+	SE::Utilz::GUID backTex;
+	SE::Utilz::GUID mesh;
+	SE::Utilz::GUID mat;
+	SE::Utilz::GUID shader;
+};
+static const std::array<ConsumableInfo, 1> consInfo = { {
+	{ "Water.png","Water.png", "Pot.mesh", "Nuckelavee.mat", "SimpleLightPS.hlsl" }
+
+	} };
+
+SE::Core::Entity SE::Gameplay::Item::Consumable::Create()
+{
+	return Create(Consumable::Type(std::rand() % int(Consumable::Type::NONE)));
+}
+
+SE::Core::Entity SE::Gameplay::Item::Consumable::Create(Consumable::Type ctype)
+{
+	auto type = std::rand() % consInfo.size();
+	auto item = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.dataManager->SetValue(item, "Item", int32_t(ItemType::CONSUMABLE));
+	CoreInit::managers.dataManager->SetValue(item, "Health", Stats::GetRandHealth() / 10 + 1);
+	CoreInit::managers.dataManager->SetValue(item, "Charges", int32_t(3));
+	CoreInit::managers.dataManager->SetValue(item, "Type", int32_t(type));
+
+	CreateMeta(item);
+	
+	return item;
+}
+
+void SE::Gameplay::Item::Consumable::CreateMeta(Core::Entity ent)
+{
+	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
+	auto itype = ItemType::CONSUMABLE;// GetRandType();
+
+	CoreInit::managers.transformManager->Create(ent);
+	CoreInit::managers.materialManager->Create(ent, { consInfo[type].shader, consInfo[type].mat });
+	CoreInit::managers.renderableManager->CreateRenderableObject(ent, { consInfo[type].mesh });
+	Core::IGUIManager::CreateInfo icon;
+	icon.texture = consInfo[type].icon;
+	icon.textureInfo.width = 50;
+	icon.textureInfo.height = 50;
+	icon.textureInfo.anchor = { 0.5f,0.5f };
+	icon.textureInfo.screenAnchor = { 0, 1 };
+	icon.textureInfo.posX = 5;
+	icon.textureInfo.posY = -60;
+	icon.textureInfo.layerDepth = 0;
+
+	CoreInit::managers.guiManager->Create(ent, icon);
+}
+using namespace SE;
+static const auto renconsInfo = [](SE::Core::Entity ent, Core::Entity parent, long posX, bool stop)
+{
+	/*long offset = -125;
+	long he = 35;
+
+	Core::ITextManager::CreateInfo ci;
+	ci.font = "CloisterBlack.spritefont";
+	ci.info.posX = posX;
+	ci.info.posY = offset;
+	ci.info.screenAnchor = { 0.5f, 0.5f };
+	ci.info.anchor = { 1,0.0f };
+	ci.info.scale = { 0.4f, 1.0f };
+	ci.info.height = he;
+	auto hp = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Health", -1));
+	ci.info.text = L"Health: " + std::to_wstring(hp);
+	auto hpEnt = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.textManager->Create(hpEnt, ci);
+	if (stop)
+	{
+		CoreInit::managers.eventManager->RegisterEntitytoEvent(hpEnt, "StopRenderItemInfo");
+	}
+	else
+	{
+		CoreInit::managers.eventManager->RegisterEntitytoEvent(hpEnt, "StopRenderWIC");
+		CoreInit::managers.dataManager->SetValue(hpEnt, "Parent", parent);
+	}
+	CoreInit::managers.textManager->ToggleRenderableText(hpEnt, true);
+	offset += he + 3;
+
+
+	Core::IGUIManager::CreateInfo ciback;
+
+	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
+
+	ciback.texture = consInfo[type].backTex;
+	ciback.textureInfo.width = 200;
+	ciback.textureInfo.height = offset + 130;
+	ciback.textureInfo.posX = posX + 5;
+	ciback.textureInfo.posY = -130;
+	ciback.textureInfo.screenAnchor = { 0.5f, 0.5f };
+	ciback.textureInfo.anchor = { 1.0, 0.0f };
+	auto weaponBack = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.guiManager->Create(weaponBack, ciback);
+	if (stop)
+	{
+		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderItemInfo");
+	}
+	else
+	{
+		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderWIC");
+		CoreInit::managers.dataManager->SetValue(weaponBack, "Parent", parent);
+	}
+	CoreInit::managers.guiManager->ToggleRenderableTexture(weaponBack, true);*/
+};
+
+void SE::Gameplay::Item::Consumable::ToggleRenderPickupInfo(Core::Entity ent)
+{
+	renconsInfo(ent, ent, -40, false);
+}
+
+void SE::Gameplay::Item::Consumable::ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent)
+{
+	renconsInfo(ent, parent, -245, true);
+}

--- a/SluaghEngine/Gameplay/Consumable.cpp
+++ b/SluaghEngine/Gameplay/Consumable.cpp
@@ -120,3 +120,66 @@ void SE::Gameplay::Item::Consumable::ToggleRenderEquiuppedInfo(Core::Entity ent,
 {
 	renconsInfo(ent, parent, -245, true);
 }
+
+void SE::Gameplay::Item::Consumable::RenderItemInfo(Core::Entity item, Core::Entity compareWith)
+{
+	long posY = -40;
+	long textHeigth = 35;
+	Core::ITextManager::CreateInfo tci;
+	auto health = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Health", 0));
+	auto healthCW = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(compareWith, "Health", 0));
+	if (health > healthCW)
+		tci.info.colour = { 0, 1.0f, 0.0f, 1.0f };
+	else if (health < healthCW)
+		tci.info.colour = { 1.0f, 0.0f, 0.0f, 1.0f };
+	else
+		tci.info.colour = { 1.0f, (165 / 255.0f), 0.0f, 1.0f };
+	//tci.info.colour = { 1.0f, 1.0f, 1.0f, 1.0f };
+	tci.font = "CloisterBlack.spritefont";
+	tci.info.posX = -40;
+	tci.info.posY = posY;
+	tci.info.screenAnchor = { 0.5f, 0.5f };
+	tci.info.anchor = { 1.0f,0.0f };
+	tci.info.scale = { 0.4f, 1.0f };
+	tci.info.height = textHeigth;
+	tci.info.text = L"Hälsa";
+	auto textEnt = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.textManager->Create(textEnt, tci);
+	CoreInit::managers.textManager->ToggleRenderableText(textEnt, true);
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(textEnt, "StopRenderItemInfo");
+	posY += textHeigth + 5;
+
+
+	auto charges = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Charges", 0));
+	auto chargesCW = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(compareWith, "Charges", 0));
+	if (charges > chargesCW)
+		tci.info.colour = { 0, 1.0f, 0.0f, 1.0f };
+	else if (charges < chargesCW)
+		tci.info.colour = { 1.0f, 0.0f, 0.0f, 1.0f };
+	else
+		tci.info.colour = { 1.0f, (165 / 255.0f), 0.0f, 1.0f };
+	tci.info.posY = posY;
+	tci.info.text = L"Klunkar";
+	textEnt = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.textManager->Create(textEnt, tci);
+	CoreInit::managers.textManager->ToggleRenderableText(textEnt, true);
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(textEnt, "StopRenderItemInfo");
+	posY += textHeigth + 5;
+
+
+	Core::IGUIManager::CreateInfo ciback;
+	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Type", -1));
+	ciback.texture = consInfo[type].backTex;
+	ciback.textureInfo.width = 125;
+	ciback.textureInfo.height = 125;
+	ciback.textureInfo.posX = -25;
+	ciback.textureInfo.posY = 0;
+	ciback.textureInfo.screenAnchor = { 0.5f, 0.5f };
+	ciback.textureInfo.anchor = { 1.0f, 0.5f };
+	auto weaponBack = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.guiManager->Create(weaponBack, ciback);
+
+	CoreInit::managers.guiManager->ToggleRenderableTexture(weaponBack, true);
+
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderItemInfo");
+}

--- a/SluaghEngine/Gameplay/Gameplay.vcxproj
+++ b/SluaghEngine/Gameplay/Gameplay.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="ChangeRoomLeaf.cpp" />
     <ClCompile Include="ChannelingCondition.cpp" />
     <ClCompile Include="CharacterCreationState.cpp" />
+    <ClCompile Include="Consumable.cpp" />
     <ClCompile Include="CoreInit.cpp" />
     <ClCompile Include="CountdownRoomTransistionLeaf.cpp" />
     <ClCompile Include="CurrentAnimationAllowsBlendingCondition.cpp" />
@@ -98,6 +99,7 @@
     <ClCompile Include="TransistionCountdownDoneCondition.cpp" />
     <ClCompile Include="TransistionToRoomLeaf.cpp" />
     <ClCompile Include="TutorialState.cpp" />
+    <ClCompile Include="Weapon.cpp" />
     <ClCompile Include="WhileChannelingLeaf.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -114,6 +116,7 @@
     <ClInclude Include="..\includes\Gameplay\ChangeRoomLeaf.h" />
     <ClInclude Include="..\includes\Gameplay\ChannelingCondition.h" />
     <ClInclude Include="..\includes\Gameplay\CharacterCreationState.h" />
+    <ClInclude Include="..\includes\Gameplay\Consumable.h" />
     <ClInclude Include="..\includes\Gameplay\CountdownRoomTransistionLeaf.h" />
     <ClInclude Include="..\includes\Gameplay\CurrentAnimationAllowsBlendingCondition.h" />
     <ClInclude Include="..\includes\Gameplay\DistanceToDoorCondition.h" />
@@ -191,6 +194,7 @@
     <ClInclude Include="..\includes\Gameplay\TransistionCountdownDoneCondition.h" />
     <ClInclude Include="..\includes\Gameplay\TransistionToRoomLeaf.h" />
     <ClInclude Include="..\includes\Gameplay\TutorialState.h" />
+    <ClInclude Include="..\includes\Gameplay\Weapon.h" />
     <ClInclude Include="..\includes\Gameplay\WhileChannelingLeaf.h" />
     <ClInclude Include="Game.h" />
     <ClInclude Include="CoreInit.h" />

--- a/SluaghEngine/Gameplay/Gameplay.vcxproj.filters
+++ b/SluaghEngine/Gameplay/Gameplay.vcxproj.filters
@@ -145,6 +145,12 @@
     <Filter Include="Source Files\Perks">
       <UniqueIdentifier>{ae18b683-1a04-47df-b06d-326c5d3c82b1}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Items">
+      <UniqueIdentifier>{069e3f6c-34a0-47b5-94a4-8e332e8d79f8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Items">
+      <UniqueIdentifier>{a08f9362-6e53-4fda-81e8-2dfd4b9874c3}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -336,9 +342,6 @@
     <ClCompile Include="PauseAnimationsLeaf.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Items.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="NuckelaveeNormalAttackLeaf.cpp">
       <Filter>Source Files\AI\BehaviouralTree\Behaviours\Leaves</Filter>
     </ClCompile>
@@ -392,6 +395,15 @@
     </ClCompile>
     <ClCompile Include="PerkFactory.cpp">
       <Filter>Source Files\Perks</Filter>
+    </ClCompile>
+    <ClCompile Include="Items.cpp">
+      <Filter>Source Files\Items</Filter>
+    </ClCompile>
+    <ClCompile Include="Weapon.cpp">
+      <Filter>Source Files\Items</Filter>
+    </ClCompile>
+    <ClCompile Include="Consumable.cpp">
+      <Filter>Source Files\Items</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -632,9 +644,6 @@
     <ClInclude Include="..\includes\Gameplay\StopAnimationsLeaf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\includes\Gameplay\Items.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\includes\Gameplay\NuckelaveeNormalAttackLeaf.h">
       <Filter>Header Files\AI\BehaviouralTree\Behaviours\Leaves</Filter>
     </ClInclude>
@@ -682,6 +691,15 @@
     </ClInclude>
     <ClInclude Include="..\includes\Gameplay\PerkFactory.h">
       <Filter>Header Files\Perks</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\Gameplay\Weapon.h">
+      <Filter>Header Files\Items</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\Gameplay\Items.h">
+      <Filter>Header Files\Items</Filter>
+    </ClInclude>
+    <ClInclude Include="..\includes\Gameplay\Consumable.h">
+      <Filter>Header Files\Items</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/SluaghEngine/Gameplay/Items.cpp
+++ b/SluaghEngine/Gameplay/Items.cpp
@@ -423,7 +423,7 @@ void SE::Gameplay::Item::Drop(Core::Entity ent, DirectX::XMFLOAT3 pos)
 	CoreInit::managers.particleSystemManager->CreateSystem(ent, { "lootParticle.pts" });
 	CoreInit::managers.particleSystemManager->ToggleVisible(ent, true);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, true);
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "WeaponPickUp");
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "ItemPickup");
 	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "StartRenderWIC");
 	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "RoomChange");
 }
@@ -436,7 +436,7 @@ void SE::Gameplay::Item::Drop(Core::Entity ent)
 	CoreInit::managers.particleSystemManager->CreateSystem(ent, { "lootParticle.pts" });
 	CoreInit::managers.particleSystemManager->ToggleVisible(ent, true);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, true);
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "WeaponPickUp");
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "ItemPickup");
 	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "StartRenderWIC");
 }
 
@@ -446,7 +446,7 @@ void SE::Gameplay::Item::Pickup(Core::Entity ent)
 	CoreInit::managers.collisionManager->Destroy(ent);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, false);
 	CoreInit::managers.guiManager->ToggleRenderableTexture(ent, true);
-	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "WeaponPickUp");
+	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "ItemPickup");
 	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "StartRenderWIC");
 	CoreInit::managers.particleSystemManager->Destroy(ent);
 	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "RoomChange");
@@ -456,7 +456,7 @@ void SE::Gameplay::Item::GodPickup(Core::Entity ent)
 {
 	CoreInit::managers.collisionManager->Destroy(ent);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, false);
-	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "WeaponPickUp");
+	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "ItemPickup");
 	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "StartRenderWIC");
 	CoreInit::managers.particleSystemManager->Destroy(ent);
 }
@@ -476,7 +476,7 @@ void SE::Gameplay::Item::Unequip(Core::Entity item, Core::Entity from)
 	auto itemType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Item", -1));
 	if (ItemType(itemType) == ItemType::WEAPON)
 	{
-		Weapon::Equip(item, from);
+		Weapon::UnEquip(item, from);
 	}
 }
 

--- a/SluaghEngine/Gameplay/Items.cpp
+++ b/SluaghEngine/Gameplay/Items.cpp
@@ -424,7 +424,7 @@ void SE::Gameplay::Item::Drop(Core::Entity ent, DirectX::XMFLOAT3 pos)
 	CoreInit::managers.particleSystemManager->ToggleVisible(ent, true);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, true);
 	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "ItemPickup");
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "StartRenderWIC");
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "RenderItemInfo");
 	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "RoomChange");
 }
 
@@ -437,7 +437,7 @@ void SE::Gameplay::Item::Drop(Core::Entity ent)
 	CoreInit::managers.particleSystemManager->ToggleVisible(ent, true);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, true);
 	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "ItemPickup");
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "StartRenderWIC");
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "RenderItemInfo");
 }
 
 void SE::Gameplay::Item::Pickup(Core::Entity ent)
@@ -447,7 +447,7 @@ void SE::Gameplay::Item::Pickup(Core::Entity ent)
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, false);
 	CoreInit::managers.guiManager->ToggleRenderableTexture(ent, true);
 	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "ItemPickup");
-	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "StartRenderWIC");
+	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "RenderItemInfo");
 	CoreInit::managers.particleSystemManager->Destroy(ent);
 	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "RoomChange");
 }
@@ -457,7 +457,7 @@ void SE::Gameplay::Item::GodPickup(Core::Entity ent)
 	CoreInit::managers.collisionManager->Destroy(ent);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(ent, false);
 	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "ItemPickup");
-	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "StartRenderWIC");
+	CoreInit::managers.eventManager->UnregisterEntitytoEvent(ent, "RenderItemInfo");
 	CoreInit::managers.particleSystemManager->Destroy(ent);
 }
 
@@ -496,4 +496,24 @@ void SE::Gameplay::Item::ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entit
 		Weapon::ToggleRenderEquiuppedInfo(ent, parent);
 	else if (item == ItemType::CONSUMABLE)
 		Consumable::ToggleRenderEquiuppedInfo(ent, parent);
+}
+
+void SE::Gameplay::Item::RenderItemInfo(Core::Entity item, Core::Entity compareWith)
+{
+	auto itemType = ItemType(std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Item", -1)));
+	if (itemType == ItemType::WEAPON)
+	{
+		if(auto itemTypeCW = ItemType(std::get<int32_t>(CoreInit::managers.dataManager->GetValue(compareWith, "Item", -1))); itemTypeCW == ItemType::WEAPON)
+			Weapon::RenderItemInfo(item, compareWith);
+		else
+			Weapon::RenderItemInfo(item, item);
+	}
+
+	else if (itemType == ItemType::CONSUMABLE)
+	{
+		if (auto itemTypeCW = ItemType(std::get<int32_t>(CoreInit::managers.dataManager->GetValue(compareWith, "Item", -1))); itemTypeCW == ItemType::CONSUMABLE)
+			Consumable::RenderItemInfo(item, compareWith);
+		else
+			Consumable::RenderItemInfo(item, item);
+	}
 }

--- a/SluaghEngine/Gameplay/Items.cpp
+++ b/SluaghEngine/Gameplay/Items.cpp
@@ -1,43 +1,8 @@
 #include <Items.h>
 #include "CoreInit.h"
 #include <array>
-struct WeaponInfo
-{
-	SE::Utilz::GUID icon;
-	SE::Utilz::GUID iconP;
-	SE::Utilz::GUID backTex;
-	SE::Utilz::GUID mesh;
-	SE::Utilz::GUID mat;
-	SE::Utilz::GUID shader;
-	SE::Utilz::GUID projectile;
-	SE::Utilz::GUID attAnim;
-	SE::Utilz::GUID equipJoint;
-	int slotIndex;
-	DirectX::XMFLOAT3 equipPos;
-	DirectX::XMFLOAT3 scale;
-	DirectX::XMFLOAT3 equipRot;
-};
-
-static const std::array<WeaponInfo, 3> weaponInfo = { {
-	{"Sword_black.png", "Sword2.png", "Physical.png", "Sword.mesh", "Sword.mat", "SimpleLightPS.hlsl", "playerMeleeProjectiles.SEP", "TopSwordAttackAnim_MCModell.anim", "LHand", 0,{ 0.2f, -0.1f, -0.5f }, {1,1,1},{ 3.0f, -0.4f, 1.3f } },
-	{"Crossbow_black.png", "Crossbow_silver.png", "Range.png", "Crossbow.mesh", "Crossbow.mat", "SimpleLightPS.hlsl", "CrossbowAttack.SEP", "TopCrossbowAttackAnim_MCModell.anim" , "LHand", 0,{0, -0.02f, -0.25f },{ 0.15f,0.15f,0.15f },{1.6f, 1.2f,0.0f } },
-	{"Wand_black.png","Wand_silver.png", "Magic.png", "WandPivotEnd.mesh", "WandPivotEnd.mat", "SimpleLightPS.hlsl", "WandAttack.SEP", "TopWandAttackAnim_MCModell.anim", "LHand", 0,{ 0.05f, 0.0f, -0.2f },{ 1,1,1 },{ 3.0f, -0.4f, 1.3f } }
-} };
 
 
-
-struct ConsumableInfo
-{
-	SE::Utilz::GUID icon;
-	SE::Utilz::GUID backTex;
-	SE::Utilz::GUID mesh;
-	SE::Utilz::GUID mat;
-	SE::Utilz::GUID shader;
-};
-static const std::array<ConsumableInfo, 1> consInfo = { {
-	{"Water.png","Water.png", "Pot.mesh", "Nuckelavee.mat", "SimpleLightPS.hlsl" }
-
-} };
 
 struct ElT
 {
@@ -54,35 +19,6 @@ static const ElT elt[4] = {
 };
 
 using namespace SE::Gameplay;
-
-int SE::Gameplay::Item::GetRandStr()
-{
-	return (CoreInit::subSystems.window->GetRand() % 20) - 10;
-}
-
-int SE::Gameplay::Item::GetRandAgi()
-{
-	return (CoreInit::subSystems.window->GetRand() % 20) - 10;
-}
-int SE::Gameplay::Item::GetRandWil()
-{
-	return (CoreInit::subSystems.window->GetRand() % 20) - 10;
-}
-
-int SE::Gameplay::Item::GetRandHealth()
-{
-	return (CoreInit::subSystems.window->GetRand() % 20) + 1;
-}
-
-int SE::Gameplay::Item::GetRandDamage()
-{
-	return (CoreInit::subSystems.window->GetRand() % 20) + 1;
-}
-
-SE::Gameplay::DamageType SE::Gameplay::Item::GetRandDamageType()
-{
-	return DamageType(CoreInit::subSystems.window->GetRand() % 4);
-}
 
 SE::Core::Entity SE::Gameplay::Item::Copy(Core::Entity toCopy)
 {
@@ -165,307 +101,308 @@ SE::Core::Entity SE::Gameplay::Item::Create(std::ifstream & file)
 	return ent;
 }
 
-
-SE::Core::Entity SE::Gameplay::Item::Weapon::Create()
-{
-	auto wep = CoreInit::managers.entityManager->Create();
-	auto type = ItemType::WEAPON;// GetRandType();
-	auto wType = WeaponType(std::rand() % weaponInfo.size());
-	auto ele = GetRandDamageType();
-	CoreInit::managers.transformManager->Create(wep);
-	CoreInit::managers.transformManager->SetScale(wep, weaponInfo[size_t(wType)].scale);
-	CoreInit::managers.materialManager->Create(wep, { weaponInfo[size_t(wType)].shader, weaponInfo[size_t(wType)].mat });
-	CoreInit::managers.renderableManager->CreateRenderableObject(wep, { weaponInfo[size_t(wType)].mesh , false, false, true});
-	Core::IGUIManager::CreateInfo icon;
-	icon.texture = weaponInfo[size_t(wType)].icon;
-	icon.textureInfo.width = 50;
-	icon.textureInfo.height = 50;
-	icon.textureInfo.anchor = {0.5f,0.5f };
-	icon.textureInfo.screenAnchor = { 0, 1 };
-	icon.textureInfo.posX = 10;
-	icon.textureInfo.posY = -60;
-	icon.textureInfo.layerDepth = 0;
-
-	CoreInit::managers.guiManager->Create(wep, icon);
-
-	CoreInit::managers.dataManager->SetValue(wep, "Item", int32_t(type));
-	CoreInit::managers.dataManager->SetValue(wep, "Health", Item::GetRandHealth());
-	CoreInit::managers.dataManager->SetValue(wep, "Str", Item::GetRandStr());
-	CoreInit::managers.dataManager->SetValue(wep, "Agi", Item::GetRandAgi());
-	CoreInit::managers.dataManager->SetValue(wep, "Wis", Item::GetRandWil());
-	CoreInit::managers.dataManager->SetValue(wep, "Damage", Item::GetRandDamage());
-	CoreInit::managers.dataManager->SetValue(wep, "Type", int32_t(wType));
-	CoreInit::managers.dataManager->SetValue(wep, "Element", int32_t(ele));
-	CoreInit::managers.dataManager->SetValue(wep, "AttAnim", weaponInfo[size_t(wType)].attAnim.id);
-	CoreInit::managers.dataManager->SetValue(wep, "AttProj", weaponInfo[size_t(wType)].projectile.id);
-
-	
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "StartRenderWIC");
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "WeaponPickUp");
-	return wep;
-}
-
-SE::Core::Entity SE::Gameplay::Item::Weapon::Create(WeaponType type)
-{
-	auto wep = CoreInit::managers.entityManager->Create();
-	auto itype = ItemType::WEAPON;// GetRandType();
-	auto wType = type;
-	auto ele = GetRandDamageType();
-	CoreInit::managers.transformManager->Create(wep);
-	CoreInit::managers.transformManager->SetScale(wep, weaponInfo[size_t(wType)].scale);
-	CoreInit::managers.materialManager->Create(wep, { weaponInfo[size_t(wType)].shader, weaponInfo[size_t(wType)].mat });
-	CoreInit::managers.renderableManager->CreateRenderableObject(wep, { weaponInfo[size_t(wType)].mesh , false, false, true });
-	Core::IGUIManager::CreateInfo icon;
-	icon.texture = weaponInfo[size_t(wType)].icon;
-	icon.textureInfo.width = 50;
-	icon.textureInfo.height = 50;
-	icon.textureInfo.anchor = { 0.5f,0.5f };
-	icon.textureInfo.screenAnchor = { 0, 1 };
-	icon.textureInfo.posX = 10;
-	icon.textureInfo.posY = -60;
-	icon.textureInfo.layerDepth = 0;
-
-	CoreInit::managers.guiManager->Create(wep, icon);
-
-	CoreInit::managers.dataManager->SetValue(wep, "Item", int32_t(itype));
-	CoreInit::managers.dataManager->SetValue(wep, "Health", Item::GetRandHealth());
-	CoreInit::managers.dataManager->SetValue(wep, "Str", Item::GetRandStr());
-	CoreInit::managers.dataManager->SetValue(wep, "Agi", Item::GetRandAgi());
-	CoreInit::managers.dataManager->SetValue(wep, "Wis", Item::GetRandWil());
-	CoreInit::managers.dataManager->SetValue(wep, "Damage", 3);
-	CoreInit::managers.dataManager->SetValue(wep, "Type", int32_t(wType));
-	CoreInit::managers.dataManager->SetValue(wep, "Element", int32_t(ele));
-	CoreInit::managers.dataManager->SetValue(wep, "AttAnim", weaponInfo[size_t(wType)].attAnim.id);
-	CoreInit::managers.dataManager->SetValue(wep, "AttProj", weaponInfo[size_t(wType)].projectile.id);
-
-
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "StartRenderWIC");
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "WeaponPickUp");
-	return wep;
-}
-
-void SE::Gameplay::Item::Weapon::CreateMeta(Core::Entity ent)
-{
-
-	auto itype = ItemType::WEAPON;
-	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
-	//auto ele = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Element", -1));
-	CoreInit::managers.transformManager->Create(ent);
-	CoreInit::managers.transformManager->SetScale(ent, weaponInfo[size_t(wType)].scale);
-	CoreInit::managers.materialManager->Create(ent, { weaponInfo[size_t(wType)].shader, weaponInfo[size_t(wType)].mat });
-	CoreInit::managers.renderableManager->CreateRenderableObject(ent, { weaponInfo[size_t(wType)].mesh , false, false, true });
-	Core::IGUIManager::CreateInfo icon;
-	icon.texture = weaponInfo[size_t(wType)].icon;
-	icon.textureInfo.width = 50;
-	icon.textureInfo.height = 50;
-	icon.textureInfo.anchor = { 0.5f,0.5f };
-	icon.textureInfo.screenAnchor = { 0, 1 };
-	icon.textureInfo.posX = 10;
-	icon.textureInfo.posY = -60;
-	icon.textureInfo.layerDepth = 0;
-
-	CoreInit::managers.guiManager->Create(ent, icon);
-
-	//CoreInit::managers.dataManager->SetValue(to, "Health", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Health", 0)));
-	//CoreInit::managers.dataManager->SetValue(to, "Str", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Str", 0)));
-	//CoreInit::managers.dataManager->SetValue(to, "Agi", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Agi", 0)));
-	//CoreInit::managers.dataManager->SetValue(to, "Wis", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Wis", 0)));
-	//CoreInit::managers.dataManager->SetValue(to, "Damage", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Damage", 0)));
-	//CoreInit::managers.dataManager->SetValue(to, "Type", int32_t(wType));
-	//CoreInit::managers.dataManager->SetValue(to, "Element", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Element", -1)));
-	//CoreInit::managers.dataManager->SetValue(to, "AttAnim", weaponInfo[size_t(wType)].attAnim.id);
-	//CoreInit::managers.dataManager->SetValue(to, "AttProj", weaponInfo[size_t(wType)].projectile.id);
-
-
-
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "StartRenderWIC");
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "WeaponPickUp");
-}
-
-using namespace SE;
-static const auto wepInfo = [](SE::Core::Entity ent, Core::Entity parent, long posX,bool stop)
-{
-	long offset = -125;
-	long he = 35;
-	Core::ITextManager::CreateInfo ciStr;
-	auto s = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Str", 0));
-	ciStr.font = "CloisterBlack.spritefont";
-	ciStr.info.posX = posX;
-	ciStr.info.posY = offset;
-	ciStr.info.screenAnchor = { 0.5f, 0.5f };
-	ciStr.info.anchor = { 1,0.0f };
-	ciStr.info.scale = { 0.4f, 1.0f };
-	ciStr.info.height = he;
-	ciStr.info.text = L"Str: " + std::to_wstring(s);
-	auto wStr = CoreInit::managers.entityManager->Create();
-	/*CoreInit::managers.textManager->Create(wStr, ciStr);
-
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(wStr, "Parent", parent);
-	}
-	
-	CoreInit::managers.textManager->ToggleRenderableText(wStr, true);
-
-	offset += he + 3;
-*/
-	s = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Agi", 0));
-	ciStr.font = "CloisterBlack.spritefont";
-	ciStr.info.posY = offset;
-	ciStr.info.text = L"Agi: " + std::to_wstring(s);
-	/*wStr = CoreInit::managers.entityManager->Create();
-	CoreInit::managers.textManager->Create(wStr, ciStr);
-
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(wStr, "Parent", parent);
-	}
-	CoreInit::managers.textManager->ToggleRenderableText(wStr, true);
-
-	offset += he + 3;
-*/
-	s = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Wis", 0));
-	ciStr.font = "CloisterBlack.spritefont";
-	ciStr.info.posY = offset;
-	ciStr.info.text = L"Wis: " + std::to_wstring(s);
-	/*wStr = CoreInit::managers.entityManager->Create();
-	CoreInit::managers.textManager->Create(wStr, ciStr);
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(wStr, "Parent", parent);
-	}
-	CoreInit::managers.textManager->ToggleRenderableText(wStr, true);
-
-	offset += he + 3;
-*/
-	Core::ITextManager::CreateInfo cielement;
-	cielement.font = "CloisterBlack.spritefont";
-	cielement.info.posX = posX;
-	cielement.info.posY = offset;
-	cielement.info.screenAnchor = { 0.5f, 0.5f };
-	cielement.info.anchor = { 1,0.0f };
-	cielement.info.scale = { 0.4f, 1.0f };
-	cielement.info.height = he;
-	auto element = DamageType(std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Element", -1)));
-	cielement.info.colour = elt[size_t(element)].color;
-	cielement.info.text = elt[size_t(element)].str;
-	/*auto weaponElement = CoreInit::managers.entityManager->Create();
-	CoreInit::managers.textManager->Create(weaponElement, cielement);
-
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponElement, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponElement, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(weaponElement, "Parent", parent);
-	}
-	CoreInit::managers.textManager->ToggleRenderableText(weaponElement, true);
-
-	offset += he + 3;
-*/
-
-	Core::ITextManager::CreateInfo cidamage;
-	cidamage.font = "CloisterBlack.spritefont";
-	cidamage.info.posX = posX;
-	cidamage.info.posY = offset;
-	cidamage.info.screenAnchor = { 0.5f, 0.5f };
-	cidamage.info.anchor = { 1,0.0f };
-	cidamage.info.scale = { 0.4f, 1.0f };
-	cidamage.info.height = he;
-	auto damage = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Damage", -1));
-	cidamage.info.text = L"Damage: " + std::to_wstring(damage);
-	auto weaponDamage = CoreInit::managers.entityManager->Create();
-	CoreInit::managers.textManager->Create(weaponDamage, cidamage);
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponDamage, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponDamage, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(weaponDamage, "Parent", parent);
-	}
-	CoreInit::managers.textManager->ToggleRenderableText(weaponDamage, true);
-	offset += he + 3;
-
-	cidamage.font = "CloisterBlack.spritefont";
-	cidamage.info.posX = posX;
-	cidamage.info.posY = offset;
-	cidamage.info.screenAnchor = { 0.5f, 0.5f };
-	cidamage.info.anchor = { 1,0.0f };
-	cidamage.info.scale = { 0.4f, 1.0f };
-	cidamage.info.height = he;
-	auto hp = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Health", -1));
-	cidamage.info.text = L"Health: " + std::to_wstring(hp);
-	auto weaponHealth = CoreInit::managers.entityManager->Create();
-	CoreInit::managers.textManager->Create(weaponHealth, cidamage);
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponHealth, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponHealth, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(weaponHealth, "Parent", parent);
-	}
-	CoreInit::managers.textManager->ToggleRenderableText(weaponHealth, true);
-	offset += he + 3;
-
-
-	Core::IGUIManager::CreateInfo ciback;
-
-	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
-
-	ciback.texture = weaponInfo[type].backTex;
-	ciback.textureInfo.width = 200;
-	ciback.textureInfo.height = offset + 130;
-	ciback.textureInfo.posX = posX+5;
-	ciback.textureInfo.posY = -130;
-	ciback.textureInfo.screenAnchor = { 0.5f, 0.5f };
-	ciback.textureInfo.anchor = { 1.0, 0.0f };
-	auto weaponBack = CoreInit::managers.entityManager->Create();
-	CoreInit::managers.guiManager->Create(weaponBack, ciback);
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(weaponBack, "Parent", parent);
-	}
-	CoreInit::managers.guiManager->ToggleRenderableTexture(weaponBack, true);
-};
-
-void SE::Gameplay::Item::Weapon::ToggleRenderPickupInfo(Core::Entity ent)
-{
-	wepInfo(ent, ent, -40, false);
-}
-
-void SE::Gameplay::Item::Weapon::ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent)
-{
-
-	wepInfo(ent, parent, -245, true);
-
-
-}
+//
+//SE::Core::Entity SE::Gameplay::Item::Weapon::Create()
+//{
+//	auto wep = CoreInit::managers.entityManager->Create();
+//	auto type = ItemType::WEAPON;// GetRandType();
+//	auto wType = WeaponType(std::rand() % weaponInfo.size());
+//	auto ele = Stats::GetRandomDamageType();
+//	CoreInit::managers.transformManager->Create(wep);
+//	CoreInit::managers.transformManager->SetScale(wep, weaponInfo[size_t(wType)].scale);
+//	CoreInit::managers.materialManager->Create(wep, { weaponInfo[size_t(wType)].shader, weaponInfo[size_t(wType)].mat });
+//	CoreInit::managers.renderableManager->CreateRenderableObject(wep, { weaponInfo[size_t(wType)].mesh , false, false, true});
+//	Core::IGUIManager::CreateInfo icon;
+//	icon.texture = weaponInfo[size_t(wType)].icon;
+//	icon.textureInfo.width = 50;
+//	icon.textureInfo.height = 50;
+//	icon.textureInfo.anchor = {0.5f,0.5f };
+//	icon.textureInfo.screenAnchor = { 0, 1 };
+//	icon.textureInfo.posX = 10;
+//	icon.textureInfo.posY = -60;
+//	icon.textureInfo.layerDepth = 0;
+//
+//	CoreInit::managers.guiManager->Create(wep, icon);
+//
+//	CoreInit::managers.dataManager->SetValue(wep, "Item", int32_t(type));
+//	CoreInit::managers.dataManager->SetValue(wep, "Health", Stats::GetRandHealth());
+//	CoreInit::managers.dataManager->SetValue(wep, "Str", Stats::GetRandStr());
+//	CoreInit::managers.dataManager->SetValue(wep, "Agi", Stats::GetRandAgi());
+//	CoreInit::managers.dataManager->SetValue(wep, "Wis", Stats::GetRandWil());
+//	CoreInit::managers.dataManager->SetValue(wep, "Damage", Stats::GetRandDamage());
+//	CoreInit::managers.dataManager->SetValue(wep, "Type", int32_t(wType));
+//	CoreInit::managers.dataManager->SetValue(wep, "Element", int32_t(ele));
+//	CoreInit::managers.dataManager->SetValue(wep, "AttAnim", weaponInfo[size_t(wType)].attAnim.id);
+//	CoreInit::managers.dataManager->SetValue(wep, "AttProj", weaponInfo[size_t(wType)].projectile.id);
+//
+//	
+//	CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "StartRenderWIC");
+//	CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "WeaponPickUp");
+//	return wep;
+//}
+//
+//
+//SE::Core::Entity SE::Gameplay::Item::Weapon::Create(WeaponType type)
+//{
+//	auto wep = CoreInit::managers.entityManager->Create();
+//	auto itype = ItemType::WEAPON;// GetRandType();
+//	auto wType = type;
+//	auto ele = Stats::GetRandomDamageType();
+//	CoreInit::managers.transformManager->Create(wep);
+//	CoreInit::managers.transformManager->SetScale(wep, weaponInfo[size_t(wType)].scale);
+//	CoreInit::managers.materialManager->Create(wep, { weaponInfo[size_t(wType)].shader, weaponInfo[size_t(wType)].mat });
+//	CoreInit::managers.renderableManager->CreateRenderableObject(wep, { weaponInfo[size_t(wType)].mesh , false, false, true });
+//	Core::IGUIManager::CreateInfo icon;
+//	icon.texture = weaponInfo[size_t(wType)].icon;
+//	icon.textureInfo.width = 50;
+//	icon.textureInfo.height = 50;
+//	icon.textureInfo.anchor = { 0.5f,0.5f };
+//	icon.textureInfo.screenAnchor = { 0, 1 };
+//	icon.textureInfo.posX = 10;
+//	icon.textureInfo.posY = -60;
+//	icon.textureInfo.layerDepth = 0;
+//
+//	CoreInit::managers.guiManager->Create(wep, icon);
+//
+//	CoreInit::managers.dataManager->SetValue(wep, "Item", int32_t(itype));
+//	CoreInit::managers.dataManager->SetValue(wep, "Health", Stats::GetRandHealth());
+//	CoreInit::managers.dataManager->SetValue(wep, "Str", Stats::GetRandStr());
+//	CoreInit::managers.dataManager->SetValue(wep, "Agi", Stats::GetRandAgi());
+//	CoreInit::managers.dataManager->SetValue(wep, "Wis", Stats::GetRandWil());
+//	CoreInit::managers.dataManager->SetValue(wep, "Damage", 3);
+//	CoreInit::managers.dataManager->SetValue(wep, "Type", int32_t(wType));
+//	CoreInit::managers.dataManager->SetValue(wep, "Element", int32_t(ele));
+//	CoreInit::managers.dataManager->SetValue(wep, "AttAnim", weaponInfo[size_t(wType)].attAnim.id);
+//	CoreInit::managers.dataManager->SetValue(wep, "AttProj", weaponInfo[size_t(wType)].projectile.id);
+//
+//
+//	CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "StartRenderWIC");
+//	CoreInit::managers.eventManager->RegisterEntitytoEvent(wep, "WeaponPickUp");
+//	return wep;
+//}
+//
+//void SE::Gameplay::Item::Weapon::CreateMeta(Core::Entity ent)
+//{
+//
+//	auto itype = ItemType::WEAPON;
+//	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
+//	//auto ele = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Element", -1));
+//	CoreInit::managers.transformManager->Create(ent);
+//	CoreInit::managers.transformManager->SetScale(ent, weaponInfo[size_t(wType)].scale);
+//	CoreInit::managers.materialManager->Create(ent, { weaponInfo[size_t(wType)].shader, weaponInfo[size_t(wType)].mat });
+//	CoreInit::managers.renderableManager->CreateRenderableObject(ent, { weaponInfo[size_t(wType)].mesh , false, false, true });
+//	Core::IGUIManager::CreateInfo icon;
+//	icon.texture = weaponInfo[size_t(wType)].icon;
+//	icon.textureInfo.width = 50;
+//	icon.textureInfo.height = 50;
+//	icon.textureInfo.anchor = { 0.5f,0.5f };
+//	icon.textureInfo.screenAnchor = { 0, 1 };
+//	icon.textureInfo.posX = 10;
+//	icon.textureInfo.posY = -60;
+//	icon.textureInfo.layerDepth = 0;
+//
+//	CoreInit::managers.guiManager->Create(ent, icon);
+//
+//	//CoreInit::managers.dataManager->SetValue(to, "Health", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Health", 0)));
+//	//CoreInit::managers.dataManager->SetValue(to, "Str", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Str", 0)));
+//	//CoreInit::managers.dataManager->SetValue(to, "Agi", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Agi", 0)));
+//	//CoreInit::managers.dataManager->SetValue(to, "Wis", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Wis", 0)));
+//	//CoreInit::managers.dataManager->SetValue(to, "Damage", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Damage", 0)));
+//	//CoreInit::managers.dataManager->SetValue(to, "Type", int32_t(wType));
+//	//CoreInit::managers.dataManager->SetValue(to, "Element", std::get<int32_t>(CoreInit::managers.dataManager->GetValue(from, "Element", -1)));
+//	//CoreInit::managers.dataManager->SetValue(to, "AttAnim", weaponInfo[size_t(wType)].attAnim.id);
+//	//CoreInit::managers.dataManager->SetValue(to, "AttProj", weaponInfo[size_t(wType)].projectile.id);
+//
+//
+//
+//	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "StartRenderWIC");
+//	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "WeaponPickUp");
+//}
+//
+//using namespace SE;
+//static const auto wepInfo = [](SE::Core::Entity ent, Core::Entity parent, long posX,bool stop)
+//{
+//	long offset = -125;
+//	long he = 35;
+//	Core::ITextManager::CreateInfo ciStr;
+//	auto s = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Str", 0));
+//	ciStr.font = "CloisterBlack.spritefont";
+//	ciStr.info.posX = posX;
+//	ciStr.info.posY = offset;
+//	ciStr.info.screenAnchor = { 0.5f, 0.5f };
+//	ciStr.info.anchor = { 1,0.0f };
+//	ciStr.info.scale = { 0.4f, 1.0f };
+//	ciStr.info.height = he;
+//	ciStr.info.text = L"Str: " + std::to_wstring(s);
+//	auto wStr = CoreInit::managers.entityManager->Create();
+//	/*CoreInit::managers.textManager->Create(wStr, ciStr);
+//
+//	if (stop)
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderItemInfo");
+//	}
+//	else
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderWIC");
+//		CoreInit::managers.dataManager->SetValue(wStr, "Parent", parent);
+//	}
+//	
+//	CoreInit::managers.textManager->ToggleRenderableText(wStr, true);
+//
+//	offset += he + 3;
+//*/
+//	s = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Agi", 0));
+//	ciStr.font = "CloisterBlack.spritefont";
+//	ciStr.info.posY = offset;
+//	ciStr.info.text = L"Agi: " + std::to_wstring(s);
+//	/*wStr = CoreInit::managers.entityManager->Create();
+//	CoreInit::managers.textManager->Create(wStr, ciStr);
+//
+//	if (stop)
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderItemInfo");
+//	}
+//	else
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderWIC");
+//		CoreInit::managers.dataManager->SetValue(wStr, "Parent", parent);
+//	}
+//	CoreInit::managers.textManager->ToggleRenderableText(wStr, true);
+//
+//	offset += he + 3;
+//*/
+//	s = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Wis", 0));
+//	ciStr.font = "CloisterBlack.spritefont";
+//	ciStr.info.posY = offset;
+//	ciStr.info.text = L"Wis: " + std::to_wstring(s);
+//	/*wStr = CoreInit::managers.entityManager->Create();
+//	CoreInit::managers.textManager->Create(wStr, ciStr);
+//	if (stop)
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderItemInfo");
+//	}
+//	else
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(wStr, "StopRenderWIC");
+//		CoreInit::managers.dataManager->SetValue(wStr, "Parent", parent);
+//	}
+//	CoreInit::managers.textManager->ToggleRenderableText(wStr, true);
+//
+//	offset += he + 3;
+//*/
+//	Core::ITextManager::CreateInfo cielement;
+//	cielement.font = "CloisterBlack.spritefont";
+//	cielement.info.posX = posX;
+//	cielement.info.posY = offset;
+//	cielement.info.screenAnchor = { 0.5f, 0.5f };
+//	cielement.info.anchor = { 1,0.0f };
+//	cielement.info.scale = { 0.4f, 1.0f };
+//	cielement.info.height = he;
+//	auto element = DamageType(std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Element", -1)));
+//	cielement.info.colour = elt[size_t(element)].color;
+//	cielement.info.text = elt[size_t(element)].str;
+//	/*auto weaponElement = CoreInit::managers.entityManager->Create();
+//	CoreInit::managers.textManager->Create(weaponElement, cielement);
+//
+//	if (stop)
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponElement, "StopRenderItemInfo");
+//	}
+//	else
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponElement, "StopRenderWIC");
+//		CoreInit::managers.dataManager->SetValue(weaponElement, "Parent", parent);
+//	}
+//	CoreInit::managers.textManager->ToggleRenderableText(weaponElement, true);
+//
+//	offset += he + 3;
+//*/
+//
+//	Core::ITextManager::CreateInfo cidamage;
+//	cidamage.font = "CloisterBlack.spritefont";
+//	cidamage.info.posX = posX;
+//	cidamage.info.posY = offset;
+//	cidamage.info.screenAnchor = { 0.5f, 0.5f };
+//	cidamage.info.anchor = { 1,0.0f };
+//	cidamage.info.scale = { 0.4f, 1.0f };
+//	cidamage.info.height = he;
+//	auto damage = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Damage", -1));
+//	cidamage.info.text = L"Damage: " + std::to_wstring(damage);
+//	auto weaponDamage = CoreInit::managers.entityManager->Create();
+//	CoreInit::managers.textManager->Create(weaponDamage, cidamage);
+//	if (stop)
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponDamage, "StopRenderItemInfo");
+//	}
+//	else
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponDamage, "StopRenderWIC");
+//		CoreInit::managers.dataManager->SetValue(weaponDamage, "Parent", parent);
+//	}
+//	CoreInit::managers.textManager->ToggleRenderableText(weaponDamage, true);
+//	offset += he + 3;
+//
+//	cidamage.font = "CloisterBlack.spritefont";
+//	cidamage.info.posX = posX;
+//	cidamage.info.posY = offset;
+//	cidamage.info.screenAnchor = { 0.5f, 0.5f };
+//	cidamage.info.anchor = { 1,0.0f };
+//	cidamage.info.scale = { 0.4f, 1.0f };
+//	cidamage.info.height = he;
+//	auto hp = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Health", -1));
+//	cidamage.info.text = L"Health: " + std::to_wstring(hp);
+//	auto weaponHealth = CoreInit::managers.entityManager->Create();
+//	CoreInit::managers.textManager->Create(weaponHealth, cidamage);
+//	if (stop)
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponHealth, "StopRenderItemInfo");
+//	}
+//	else
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponHealth, "StopRenderWIC");
+//		CoreInit::managers.dataManager->SetValue(weaponHealth, "Parent", parent);
+//	}
+//	CoreInit::managers.textManager->ToggleRenderableText(weaponHealth, true);
+//	offset += he + 3;
+//
+//
+//	Core::IGUIManager::CreateInfo ciback;
+//
+//	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
+//
+//	ciback.texture = weaponInfo[type].backTex;
+//	ciback.textureInfo.width = 200;
+//	ciback.textureInfo.height = offset + 130;
+//	ciback.textureInfo.posX = posX+5;
+//	ciback.textureInfo.posY = -130;
+//	ciback.textureInfo.screenAnchor = { 0.5f, 0.5f };
+//	ciback.textureInfo.anchor = { 1.0, 0.0f };
+//	auto weaponBack = CoreInit::managers.entityManager->Create();
+//	CoreInit::managers.guiManager->Create(weaponBack, ciback);
+//	if (stop)
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderItemInfo");
+//	}
+//	else
+//	{
+//		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderWIC");
+//		CoreInit::managers.dataManager->SetValue(weaponBack, "Parent", parent);
+//	}
+//	CoreInit::managers.guiManager->ToggleRenderableTexture(weaponBack, true);
+//};
+//
+//void SE::Gameplay::Item::Weapon::ToggleRenderPickupInfo(Core::Entity ent)
+//{
+//	wepInfo(ent, ent, -40, false);
+//}
+//
+//void SE::Gameplay::Item::Weapon::ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent)
+//{
+//
+//	wepInfo(ent, parent, -245, true);
+//
+//
+//}
 
 SE::Core::Entity SE::Gameplay::Item::Create()
 {
@@ -524,30 +461,22 @@ void SE::Gameplay::Item::GodPickup(Core::Entity ent)
 	CoreInit::managers.particleSystemManager->Destroy(ent);
 }
 
-void SE::Gameplay::Item::Equip(Core::Entity to, Core::Entity ent)
+void SE::Gameplay::Item::Equip(Core::Entity item, Core::Entity to)
 {
-	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
-	if (wType != -1)
+	auto itemType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Item", -1));
+	if (ItemType(itemType) == ItemType::WEAPON)
 	{
-		CoreInit::managers.guiManager->SetTexture(ent, weaponInfo[wType].iconP);
-		CoreInit::managers.transformManager->SetPosition(ent, weaponInfo[wType].equipPos);
-		CoreInit::managers.transformManager->SetRotation(ent, weaponInfo[wType].equipRot.x, weaponInfo[wType].equipRot.y, weaponInfo[wType].equipRot.z);
-		CoreInit::managers.animationManager->AttachToEntity(to, ent, weaponInfo[wType].equipJoint, weaponInfo[wType].slotIndex);
-		CoreInit::managers.renderableManager->ToggleRenderableObject(ent, true);
+		Weapon::Equip(item, to);
 	}
 
 }
 
-void SE::Gameplay::Item::Unequip(Core::Entity from ,Core::Entity ent)
+void SE::Gameplay::Item::Unequip(Core::Entity item, Core::Entity from)
 {
-	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
-	if (wType != -1)
+	auto itemType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Item", -1));
+	if (ItemType(itemType) == ItemType::WEAPON)
 	{
-		//CoreInit::managers.transformManager->SetPosition(ent, { 0.07f,0.15f,0.5f });
-		//CoreInit::managers.transformManager->SetRotation(ent, -0.25f, 0.2f, 1.5f);
-		CoreInit::managers.guiManager->SetTexture(ent, weaponInfo[wType].icon);
-		CoreInit::managers.animationManager->DettachFromEntity(from, weaponInfo[wType].slotIndex);
-		CoreInit::managers.renderableManager->ToggleRenderableObject(ent, false);
+		Weapon::Equip(item, from);
 	}
 }
 
@@ -567,156 +496,4 @@ void SE::Gameplay::Item::ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entit
 		Weapon::ToggleRenderEquiuppedInfo(ent, parent);
 	else if (item == ItemType::CONSUMABLE)
 		Consumable::ToggleRenderEquiuppedInfo(ent, parent);
-}
-
-SE::Core::Entity SE::Gameplay::Item::Consumable::Create()
-{
-	auto type = std::rand() % consInfo.size();
-	auto item = CoreInit::managers.entityManager->Create();
-	auto itype = ItemType::CONSUMABLE;// GetRandType();
-
-	CoreInit::managers.transformManager->Create(item);
-	CoreInit::managers.materialManager->Create(item, { consInfo[type].shader, consInfo[type].mat});
-	CoreInit::managers.renderableManager->CreateRenderableObject(item, { consInfo[type].mesh });
-	Core::IGUIManager::CreateInfo icon;
-	icon.texture = consInfo[type].icon;
-	icon.textureInfo.width = 50;
-	icon.textureInfo.height = 50;
-	icon.textureInfo.anchor = { 0.5f,0.5f };
-	icon.textureInfo.screenAnchor = { 0, 1 };
-	icon.textureInfo.posX = 5;
-	icon.textureInfo.posY = -60;
-	icon.textureInfo.layerDepth = 0;
-
-	CoreInit::managers.guiManager->Create(item , icon);
-
-	CoreInit::managers.dataManager->SetValue(item, "Item", int32_t(itype));
-	CoreInit::managers.dataManager->SetValue(item, "Health", Item::GetRandHealth());
-	CoreInit::managers.dataManager->SetValue(item, "Charges", int32_t(3));
-	CoreInit::managers.dataManager->SetValue(item, "Type", int32_t(type));
-
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(item, "StartRenderWIC");
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(item, "WeaponPickUp");
-	return item;
-}
-
-Core::Entity SE::Gameplay::Item::Consumable::Create(ConsumableType ctype)
-{
-	auto type = std::rand() % consInfo.size();
-	auto item = CoreInit::managers.entityManager->Create();
-	auto itype = ItemType::CONSUMABLE;// GetRandType();
-
-	CoreInit::managers.transformManager->Create(item);
-	CoreInit::managers.materialManager->Create(item, { consInfo[type].shader, consInfo[type].mat });
-	CoreInit::managers.renderableManager->CreateRenderableObject(item, { consInfo[type].mesh });
-	Core::IGUIManager::CreateInfo icon;
-	icon.texture = consInfo[type].icon;
-	icon.textureInfo.width = 50;
-	icon.textureInfo.height = 50;
-	icon.textureInfo.anchor = { 0.5f,0.5f };
-	icon.textureInfo.screenAnchor = { 0, 1 };
-	icon.textureInfo.posX = 5;
-	icon.textureInfo.posY = -60;
-	icon.textureInfo.layerDepth = 0;
-
-	CoreInit::managers.guiManager->Create(item, icon);
-
-	CoreInit::managers.dataManager->SetValue(item, "Item", int32_t(itype));
-	CoreInit::managers.dataManager->SetValue(item, "Health", Item::GetRandHealth());
-	CoreInit::managers.dataManager->SetValue(item, "Charges", int32_t(3));
-	CoreInit::managers.dataManager->SetValue(item, "Type", int32_t(type));
-
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(item, "StartRenderWIC");
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(item, "WeaponPickUp");
-	return item;
-}
-
-void SE::Gameplay::Item::Consumable::CreateMeta(Core::Entity ent)
-{
-	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
-	auto itype = ItemType::CONSUMABLE;// GetRandType();
-
-	CoreInit::managers.transformManager->Create(ent);
-	CoreInit::managers.materialManager->Create(ent, { consInfo[type].shader, consInfo[type].mat });
-	CoreInit::managers.renderableManager->CreateRenderableObject(ent, { consInfo[type].mesh });
-	Core::IGUIManager::CreateInfo icon;
-	icon.texture = consInfo[type].icon;
-	icon.textureInfo.width = 50;
-	icon.textureInfo.height = 50;
-	icon.textureInfo.anchor = { 0.5f,0.5f };
-	icon.textureInfo.screenAnchor = { 0, 1 };
-	icon.textureInfo.posX = 5;
-	icon.textureInfo.posY = -60;
-	icon.textureInfo.layerDepth = 0;
-
-	CoreInit::managers.guiManager->Create(ent, icon);
-
-
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "StartRenderWIC");
-	CoreInit::managers.eventManager->RegisterEntitytoEvent(ent, "WeaponPickUp");
-}
-
-static const auto renconsInfo = [](SE::Core::Entity ent, Core::Entity parent, long posX, bool stop)
-{
-	long offset = -125;
-	long he = 35;
-	
-	Core::ITextManager::CreateInfo ci;
-	ci.font = "CloisterBlack.spritefont";
-	ci.info.posX = posX;
-	ci.info.posY = offset;
-	ci.info.screenAnchor = { 0.5f, 0.5f };
-	ci.info.anchor = { 1,0.0f };
-	ci.info.scale = { 0.4f, 1.0f };
-	ci.info.height = he;
-	auto hp = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Health", -1));
-	ci.info.text = L"Health: " + std::to_wstring(hp);
-	auto hpEnt = CoreInit::managers.entityManager->Create();
-	CoreInit::managers.textManager->Create(hpEnt, ci);
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(hpEnt, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(hpEnt, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(hpEnt, "Parent", parent);
-	}
-	CoreInit::managers.textManager->ToggleRenderableText(hpEnt, true);
-	offset += he + 3;
-
-
-	Core::IGUIManager::CreateInfo ciback;
-
-	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(ent, "Type", -1));
-
-	ciback.texture = consInfo[type].backTex;
-	ciback.textureInfo.width = 200;
-	ciback.textureInfo.height = offset + 130;
-	ciback.textureInfo.posX = posX + 5;
-	ciback.textureInfo.posY = -130;
-	ciback.textureInfo.screenAnchor = { 0.5f, 0.5f };
-	ciback.textureInfo.anchor = { 1.0, 0.0f };
-	auto weaponBack = CoreInit::managers.entityManager->Create();
-	CoreInit::managers.guiManager->Create(weaponBack, ciback);
-	if (stop)
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderItemInfo");
-	}
-	else
-	{
-		CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderWIC");
-		CoreInit::managers.dataManager->SetValue(weaponBack, "Parent", parent);
-	}
-	CoreInit::managers.guiManager->ToggleRenderableTexture(weaponBack, true);
-};
-
-void SE::Gameplay::Item::Consumable::ToggleRenderPickupInfo(Core::Entity ent)
-{
-	renconsInfo(ent, ent, -40, false);
-}
-
-void SE::Gameplay::Item::Consumable::ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent)
-{
-	renconsInfo(ent, parent, -245, true);
 }

--- a/SluaghEngine/Gameplay/PlayState.cpp
+++ b/SluaghEngine/Gameplay/PlayState.cpp
@@ -600,7 +600,7 @@ void PlayState::InitializePlayer(void* playerInfo)
 				player->SetZPosition(0.9f);
 				player->PositionEntity(x + (0.5f + xOffset), y + (0.5f + yOffset));
 
-				auto startWeapon = Item::Weapon::Create(WeaponType(std::rand() % 3));
+				auto startWeapon = Item::Weapon::Create(Item::Weapon::Type(std::rand() % 3));
 				player->AddItem(startWeapon, 0);
 				//auto wc = Item::Copy(startWeapon);
 				//player->AddItem(wc, 1);

--- a/SluaghEngine/Gameplay/PlayerUnit.cpp
+++ b/SluaghEngine/Gameplay/PlayerUnit.cpp
@@ -441,18 +441,15 @@ void SE::Gameplay::PlayerUnit::UpdateActions(float dt, std::vector<ProjectileDat
 			{
 				auto pit = ItemType(std::get<int32_t>(CoreInit::managers.dataManager->GetValue(items[currentItem], "Item", -1)));
 				if(pit == ItemType::WEAPON)
-					Item::Unequip(unitEntity, items[currentItem]);
+					Item::Unequip(items[currentItem], unitEntity);
 
 				currentItem = newItem;
-				Item::Equip(unitEntity, items[currentItem]);
-				//CoreInit::managers.guiManager->SetTexturePos(itemSelectedEntity, 40 + currentItem * 55, -55);
+				Item::Equip(items[currentItem], unitEntity);
 
 				SetCurrentWeaponStats();
 			}
 			else if (item == ItemType::CONSUMABLE)
 			{
-				//Item::Unequip(unitEntity, items[pi]);
-				//CoreInit::managers.guiManager->SetTexturePos(itemSelectedEntity, 40 + currentItem * 55, -55);
 				auto charges = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(items[newItem], "Charges", 0));
 				if (charges > 0)
 				{
@@ -669,7 +666,7 @@ void SE::Gameplay::PlayerUnit::AddItem(Core::Entity item, uint8_t slot)
 		{
 			auto ctype = (ItemType)(std::get<int32_t>(CoreInit::managers.dataManager->GetValue(items[currentItem], "Item", -1)));
 			if (ctype == ItemType::WEAPON)
-				Item::Unequip(unitEntity, items[currentItem]);
+				Item::Unequip(items[currentItem], unitEntity);
 		}
 		
 		Item::Drop(items[slot], p);
@@ -950,34 +947,9 @@ SE::Gameplay::PlayerUnit::PlayerUnit(Skill* skills, void* perks, float xPos, flo
 
 	CoreInit::managers.eventManager->RegisterEntitytoEvent(unitEntity, "StartRenderItemInfo");
 
-
-	/*items[currentItem] = Item::Weapon::Create(WeaponType(std::rand() % 3));
-	CoreInit::managers.guiManager->SetTexturePos(items[currentItem], 45 + currentItem * 60, -55);
-	Item::Pickup(items[currentItem]);
-	Item::Equip(unitEntity,items[currentItem]);
-
-	SetCurrentWeaponStats();*/
 	itemSelectedEntity = CoreInit::managers.entityManager->Create();
 	CoreInit::managers.entityManager->Destroy(itemSelectedEntity);
-	/*itemSelectedEntity = CoreInit::managers.entityManager->Create();
-	Core::IGUIManager::CreateInfo ise;
-	ise.texture = "damageFrame.png";
-	ise.textureInfo.width = CoreInit::subSystems.optionsHandler->GetOptionUnsignedInt("Window", "width", 1280);
-	ise.textureInfo.height = CoreInit::subSystems.optionsHandler->GetOptionUnsignedInt("Window", "height", 720);;
-	ise.textureInfo.layerDepth = 0.0;
-	ise.textureInfo.anchor = { 0.0f, 0.0f };
-	ise.textureInfo.screenAnchor = { 0, 0 };
-	ise.textureInfo.posX = 0;
-	ise.textureInfo.posY = 0;
-	CoreInit::managers.guiManager->Create(itemSelectedEntity, ise);
-	CoreInit::managers.guiManager->ToggleRenderableTexture(itemSelectedEntity, true);
-
-	Core::IEventManager::EventCallbacks dmgCB;
-	dmgCB.triggerCheck = [](Core::Entity ent, void*data)
-	{
-		return true;
-	}
-*/
+	
 
 	StopProfile;
 }

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -1512,6 +1512,11 @@ bool Room::AddEnemyToRoom(SE::Gameplay::EnemyUnit *enemyToAdd, DirectionToAdjace
 
 void SE::Gameplay::Room::RemoveEnemyFromRoom(SE::Gameplay::EnemyUnit * enemyToRemove)
 {
+	if (enemyToRemove == nullptr)
+	{
+		for (auto enemy : enemyUnits)
+			enemy->SetHealth(-1);
+	}
 	int counter = 0;
 	for(auto enemy : enemyUnits)
 	{

--- a/SluaghEngine/Gameplay/Sluagh.cpp
+++ b/SluaghEngine/Gameplay/Sluagh.cpp
@@ -132,9 +132,9 @@ float SE::Gameplay::Sluagh::UtilityForChangingWeapon(float dt, int & weaponToSwa
 	auto playerWeapon = thePlayer->GetCurrentItem();
 
 	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(playerWeapon, "Type", -1));
-	WeaponType playerWeaponType = WeaponType::NONE;
+	Item::Weapon::Type playerWeaponType = Item::Weapon::Type::NONE;
 	if (type != int32_t(-1))
-		playerWeaponType = WeaponType(type);
+		playerWeaponType = Item::Weapon::Type(type);
 	
 	auto sluaghWeapons = theSluagh->GetAllItems();
 
@@ -143,10 +143,10 @@ float SE::Gameplay::Sluagh::UtilityForChangingWeapon(float dt, int & weaponToSwa
 		if((type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(sluaghWeapons[i], "Type", -1))) != -1)
 		{
 			float swapUtility = 0.f;
-			auto sluaghWeaponType = WeaponType(type);
+			auto sluaghWeaponType = Item::Weapon::Type(type);
 			switch(sluaghWeaponType)
 			{
-			case WeaponType::SWORD:
+			case Item::Weapon::Type::SWORD:
 				if (distanceToPlayer > 2.5f)
 				{
 					swapUtility = 0.f;
@@ -154,7 +154,7 @@ float SE::Gameplay::Sluagh::UtilityForChangingWeapon(float dt, int & weaponToSwa
 				}
 				else
 					swapUtility += 1.f;
-				if (playerWeaponType == WeaponType::CROSSBOW || playerWeaponType == WeaponType::WAND)
+				if (playerWeaponType == Item::Weapon::Type::CROSSBOW || playerWeaponType == Item::Weapon::Type::WAND)
 				{
 					/*Disadvantage for the Sluagh*/
 					swapUtility -= 0.5f;
@@ -163,14 +163,14 @@ float SE::Gameplay::Sluagh::UtilityForChangingWeapon(float dt, int & weaponToSwa
 
 				break;
 				
-			case WeaponType::CROSSBOW: /*Fall through, only checking ranged*/
-			case WeaponType::WAND:
+			case Item::Weapon::Type::CROSSBOW: /*Fall through, only checking ranged*/
+			case Item::Weapon::Type::WAND:
 				if (distanceToPlayer < 2.5f)
 				{
 					swapUtility -= 1.f;
 					break;
 				}
-				if (playerWeaponType == WeaponType::SWORD)
+				if (playerWeaponType == Item::Weapon::Type::SWORD)
 				{
 					/*Disadvantage for the Sluagh*/
 					swapUtility += 0.5f;
@@ -215,14 +215,14 @@ float SE::Gameplay::Sluagh::UtilityForMoveInDirection(float dt, MovementDirectio
 		
 
 	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(thePlayer->GetCurrentItem(), "Type", -1));
-	WeaponType playerWeaponType = WeaponType::NONE;
+	Item::Weapon::Type playerWeaponType = Item::Weapon::Type::NONE;
 	if (type != int32_t(-1))
-		playerWeaponType = WeaponType(type);
+		playerWeaponType = Item::Weapon::Type(type);
 
 	type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(theSluagh->GetCurrentItem(), "Type", -1));
-	WeaponType sluaghWeaponType = WeaponType::NONE;
+	Item::Weapon::Type sluaghWeaponType = Item::Weapon::Type::NONE;
 	if (type != int32_t(-1))
-		sluaghWeaponType = WeaponType(type);
+		sluaghWeaponType = Item::Weapon::Type(type);
 
 	PlayerUnit::MovementInput moveEvaluate(false, false, false, false, false, thePlayer->GetXPosition(), thePlayer->GetYPosition());
 
@@ -246,7 +246,7 @@ float SE::Gameplay::Sluagh::UtilityForMoveInDirection(float dt, MovementDirectio
 
 
 	/*Check the weapon combinations, adapt the behaviour after that*/
-	if(sluaghWeaponType == WeaponType::SWORD && playerWeaponType == WeaponType::SWORD) /*Both wields melee weapon -> Sluagh moves towards the player*/
+	if(sluaghWeaponType == Item::Weapon::Type::SWORD && playerWeaponType == Item::Weapon::Type::SWORD) /*Both wields melee weapon -> Sluagh moves towards the player*/
 	{
 		float xDifference = theSluagh->GetXPosition() - thePlayer->GetXPosition();
 		float yDifference = theSluagh->GetYPosition() - thePlayer->GetYPosition();
@@ -260,7 +260,7 @@ float SE::Gameplay::Sluagh::UtilityForMoveInDirection(float dt, MovementDirectio
 			utilityValue = 0.f;
 		
 	}
-	else if((sluaghWeaponType == WeaponType::CROSSBOW || sluaghWeaponType == WeaponType::WAND) && playerWeaponType == WeaponType::SWORD) /*Player Melee, Sluagh Ranged*/
+	else if((sluaghWeaponType == Item::Weapon::Type::CROSSBOW || sluaghWeaponType == Item::Weapon::Type::WAND) && playerWeaponType == Item::Weapon::Type::SWORD) /*Player Melee, Sluagh Ranged*/
 	{
 		float xDifference = theSluagh->GetXPosition() - thePlayer->GetXPosition();
 		float yDifference = theSluagh->GetYPosition() - thePlayer->GetYPosition();
@@ -280,7 +280,7 @@ float SE::Gameplay::Sluagh::UtilityForMoveInDirection(float dt, MovementDirectio
 		else
 			utilityValue += 0.75f;
 	}
-	else if(sluaghWeaponType == WeaponType::SWORD && (playerWeaponType == WeaponType::CROSSBOW || playerWeaponType == WeaponType::WAND)) /*Player Ranged, Sluagh Melee*/
+	else if(sluaghWeaponType == Item::Weapon::Type::SWORD && (playerWeaponType == Item::Weapon::Type::CROSSBOW || playerWeaponType == Item::Weapon::Type::WAND)) /*Player Ranged, Sluagh Melee*/
 	{
 		float xDifference = theSluagh->GetXPosition() - thePlayer->GetXPosition();
 		float yDifference = theSluagh->GetYPosition() - thePlayer->GetYPosition();
@@ -293,7 +293,7 @@ float SE::Gameplay::Sluagh::UtilityForMoveInDirection(float dt, MovementDirectio
 		if (distAfterMove < 2.0f)
 			utilityValue = 0.f;		
 	}
-	else if(playerWeaponType == WeaponType::NONE) /*CONFUSED SCREAMING*/
+	else if(playerWeaponType == Item::Weapon::Type::NONE) /*CONFUSED SCREAMING*/
 	{
 		float xDifference = theSluagh->GetXPosition() - thePlayer->GetXPosition();
 		float yDifference = theSluagh->GetYPosition() - thePlayer->GetYPosition();

--- a/SluaghEngine/Gameplay/TutorialState.cpp
+++ b/SluaghEngine/Gameplay/TutorialState.cpp
@@ -155,7 +155,7 @@ SE::Gameplay::TutorialState::TutorialState()
 	subSystems.window->UpdateTime();
 	scriptToRun = &TutorialState::GreetingScript;
 
-//scriptToRun = &TutorialState::SpawnaGlastigScript;
+//scriptToRun = &TutorialState::SpawnAndScript;
 
 }
 
@@ -372,47 +372,34 @@ void SE::Gameplay::TutorialState::SpawnPickupWeaponScript(float dt)
 
 	auto pe = player->GetEntity();
 
-	Core::IEventManager::EntityEventCallbacks startrenderWIC;
-	startrenderWIC.triggerCheck = [pe](const Core::Entity ent)
+	Core::IEventManager::EntityEventCallbacks renderItemInfoEC;
+	renderItemInfoEC.triggerCheck = [pe](const Core::Entity ent)
 	{
-		auto vis = std::get<bool>(managers.dataManager->GetValue(pe, "WICV", false));
-		if (vis && !CoreInit::subSystems.window->ButtonPressed(GameInput::PICKUP))
-			return false;
 		if (!CoreInit::subSystems.window->ButtonDown(GameInput::SHOWINFO))
 			return false;
-		return managers.collisionManager->CheckCollision(ent, pe);
+
+		if (auto visible = std::get<bool>(CoreInit::managers.dataManager->GetValue(pe, "InfoVisible", false)); visible)
+			return false;
+
+		return CoreInit::managers.collisionManager->CheckCollision(ent, pe);
 	};
 
-
-	startrenderWIC.triggerCallback = [pe, this, ent](const Core::Entity ent2)
+	renderItemInfoEC.triggerCallback = [pe, this,ent](const Core::Entity ent2)
 	{
-		managers.dataManager->SetValue(pe, "WICV", true);
-		Item::ToggleRenderPickupInfo(ent2);
+		CoreInit::managers.eventManager->TriggerEvent("StopRenderItemInfo", true);
+		CoreInit::subSystems.devConsole->PrintChannel("Debug", "Render");
+		Item::RenderItemInfo(ent2, player->GetItemToCompareWith());
+		CoreInit::managers.dataManager->SetValue(pe, "InfoVisible", true);
 		scriptToRun = &TutorialState::PickupWeaponScript;
 		managers.entityManager->Destroy(ent);
 	};
 
-	Core::IEventManager::EntityEventCallbacks stoprenderWIC;
-	stoprenderWIC.triggerCheck = [pe](const Core::Entity ent)
-	{
-		if (auto parent = std::get_if<Core::Entity>(&managers.dataManager->GetValue(ent, "Parent", false)))
-		{
-			if (!managers.collisionManager->CheckCollision(*parent, pe)) {
-				return true;
-			}
-		}
-
-		return (!CoreInit::subSystems.window->ButtonDown(GameInput::SHOWINFO)) || CoreInit::subSystems.window->ButtonPressed(GameInput::PICKUP);
-	};
-
-	stoprenderWIC.triggerCallback = [pe](const Core::Entity ent)
-	{
-		managers.entityManager->DestroyNow(ent);
-		auto parent = std::get<Core::Entity>(managers.dataManager->GetValue(ent, "Parent", Core::Entity()));
-		managers.dataManager->SetValue(pe, "WICV", false);
-	};
-	managers.eventManager->RegisterEntityEvent("StartRenderWIC", startrenderWIC);
-	managers.eventManager->RegisterEntityEvent("StopRenderWIC", stoprenderWIC);
+	CoreInit::managers.eventManager->RegisterEntityEvent("RenderItemInfo", renderItemInfoEC);
+	CoreInit::managers.eventManager->RegisterTriggerEvent("StopRenderItemInfo", [pe](const Core::Entity ent) {
+		CoreInit::subSystems.devConsole->PrintChannel("Debug", "StopRender");
+		CoreInit::managers.entityManager->Destroy(ent);
+		CoreInit::managers.dataManager->SetValue(pe, "InfoVisible", false);
+	});
 
 	Core::IEventManager::EntityEventCallbacks pickUpEvent;
 	pickUpEvent.triggerCallback = [this](const Core::Entity ent) {
@@ -456,44 +443,31 @@ void SE::Gameplay::TutorialState::PickupWeaponScript(float dt)
 
 	auto pe = player->GetEntity();
 
-	Core::IEventManager::EntityEventCallbacks startrenderWIC;
-	startrenderWIC.triggerCheck = [pe](const Core::Entity ent)
+	Core::IEventManager::EntityEventCallbacks renderItemInfoEC;
+	renderItemInfoEC.triggerCheck = [pe](const Core::Entity ent)
 	{
-		auto vis = std::get<bool>(managers.dataManager->GetValue(pe, "WICV", false));
-		if (vis && !CoreInit::subSystems.window->ButtonPressed(GameInput::PICKUP))
-			return false;
 		if (!CoreInit::subSystems.window->ButtonDown(GameInput::SHOWINFO))
 			return false;
-		return managers.collisionManager->CheckCollision(ent, pe);
-	};
 
-	startrenderWIC.triggerCallback = [pe, this](const Core::Entity ent)
+		if (auto visible = std::get<bool>(CoreInit::managers.dataManager->GetValue(pe, "InfoVisible", false)); visible)
+			return false;
+
+		return CoreInit::managers.collisionManager->CheckCollision(ent, pe);
+	};
+	renderItemInfoEC.triggerCallback = [pe, this](const Core::Entity ent)
 	{
-		managers.dataManager->SetValue(pe, "WICV", true);
-		Item::ToggleRenderPickupInfo(ent);
+		CoreInit::managers.eventManager->TriggerEvent("StopRenderItemInfo", true);
+		CoreInit::subSystems.devConsole->PrintChannel("Debug", "Render");
+		Item::RenderItemInfo(ent, player->GetItemToCompareWith());
+		CoreInit::managers.dataManager->SetValue(pe, "InfoVisible", true);
 	};
 
-	Core::IEventManager::EntityEventCallbacks stoprenderWIC;
-	stoprenderWIC.triggerCheck = [pe](const Core::Entity ent)
-	{
-		if (auto parent = std::get_if<Core::Entity>(&managers.dataManager->GetValue(ent, "Parent", false)))
-		{
-			if (!managers.collisionManager->CheckCollision(*parent, pe)) {
-				return true;
-			}
-		}
-
-		return (!CoreInit::subSystems.window->ButtonDown(GameInput::SHOWINFO)) || CoreInit::subSystems.window->ButtonPressed(GameInput::PICKUP);
-	};
-
-	stoprenderWIC.triggerCallback = [pe](const Core::Entity ent)
-	{
-		managers.entityManager->DestroyNow(ent);
-		auto parent = std::get<Core::Entity>(managers.dataManager->GetValue(ent, "Parent", Core::Entity()));
-		managers.dataManager->SetValue(pe, "WICV", false);
-	};
-	managers.eventManager->RegisterEntityEvent("StartRenderWIC", startrenderWIC);
-	managers.eventManager->RegisterEntityEvent("StopRenderWIC", stoprenderWIC);
+	CoreInit::managers.eventManager->RegisterEntityEvent("RenderItemInfo", renderItemInfoEC);
+	CoreInit::managers.eventManager->RegisterTriggerEvent("StopRenderItemInfo", [pe](const Core::Entity ent) {
+		CoreInit::subSystems.devConsole->PrintChannel("Debug", "StopRender");
+		CoreInit::managers.entityManager->Destroy(ent);
+		CoreInit::managers.dataManager->SetValue(pe, "InfoVisible", false);
+	});
 
 	Core::IEventManager::EntityEventCallbacks pickUpEvent;
 	pickUpEvent.triggerCallback = [this, ent](const Core::Entity ent2) {
@@ -506,6 +480,7 @@ void SE::Gameplay::TutorialState::PickupWeaponScript(float dt)
 			managers.dataManager->SetValue(ent2, "Pickup", true);
 			scriptToRun = &TutorialState::UtmärktPickupWeaponScript;
 			managers.entityManager->Destroy(ent);
+			CoreInit::managers.eventManager->TriggerEvent("StopRenderItemInfo", false);
 		}
 
 
@@ -1022,12 +997,27 @@ void SE::Gameplay::TutorialState::GåTillSluaghSvartScript(float dt)
 	Utilz::GUID anims[] = { "TopSwordAttackAnim_MCModell.anim","BottomIdleAnim_MCModell.anim" };
 	managers.animationManager->Start(sluagh, anims, 2, 2, Core::AnimationFlags::IMMEDIATE);
 
+	auto sword = Item::Weapon::Create(Item::Weapon::Type::SWORD);
+	Item::Equip(sword, sluagh);
+
+
+
+	auto& l = managers.entityManager->Create();
+	Core::ILightManager::CreateInfo d;
+	d.radius = 100.0f;
+	d.pos = { 0.0f, 10.0f, 0.0f };
+	d.color = { 1, 1, 1 };
+	managers.lightManager->Create(l, d);
+	managers.lightManager->ToggleLight(l, true);
 
 	managers.eventManager->SetLifetime(sluagh, 4.0f);
 
-	managers.eventManager->RegisterTriggerEvent("OnDeath", [this](Core::Entity ent) {
+
+	managers.eventManager->RegisterTriggerEvent("OnDeath", [this, sword, l](Core::Entity ent) {
 		scriptToRun = &TutorialState::EndTutorialScript;
 		managers.entityManager->Destroy(ent);
+		managers.entityManager->Destroy(sword);
+		managers.entityManager->Destroy(l);
 	});
 
 	managers.eventManager->RegisterEntitytoEvent(sluagh, "OnDeath");

--- a/SluaghEngine/Gameplay/TutorialState.cpp
+++ b/SluaghEngine/Gameplay/TutorialState.cpp
@@ -3,12 +3,13 @@
 #include <Room.h>
 #include <PlayerUnit.h>
 #include <ProjectileData.h>
+#include <Items.h>
 
 using namespace DirectX;
 
 static SE::Core::IEngine::ManagerWrapper managers;
 static SE::Core::IEngine::Subsystems subSystems;
-#include <Items.h>
+
 SE::Gameplay::TutorialState::TutorialState()
 {
 	managers = CoreInit::managers;
@@ -382,6 +383,7 @@ void SE::Gameplay::TutorialState::SpawnPickupWeaponScript(float dt)
 		return managers.collisionManager->CheckCollision(ent, pe);
 	};
 
+
 	startrenderWIC.triggerCallback = [pe, this, ent](const Core::Entity ent2)
 	{
 		managers.dataManager->SetValue(pe, "WICV", true);
@@ -433,7 +435,7 @@ void SE::Gameplay::TutorialState::SpawnPickupWeaponScript(float dt)
 	managers.eventManager->RegisterEntityEvent("WeaponPickUp", pickUpEvent);
 
 
-	auto wep = Item::Weapon::Create(WeaponType::SWORD);
+	auto wep = Item::Weapon::Create(Item::Weapon::Type::SWORD);
 	Item::Drop(wep, { 5.5f,0.0f, 10.5f });
 }
 
@@ -608,7 +610,7 @@ void SE::Gameplay::TutorialState::BytaVapenAddInitScript(float dt)
 	});
 	managers.eventManager->RegisterEntitytoEvent(ent, "DelBytVapenText");
 
-	player->AddItem(Item::Weapon::Create(WeaponType::WAND), 1);
+	player->AddItem(Item::Weapon::Create(Item::Weapon::Type::WAND), 1);
 
 	scriptToRun = &TutorialState::BytaVapenAddScript;
 

--- a/SluaghEngine/Gameplay/TutorialState.cpp
+++ b/SluaghEngine/Gameplay/TutorialState.cpp
@@ -432,7 +432,7 @@ void SE::Gameplay::TutorialState::SpawnPickupWeaponScript(float dt)
 	};
 
 
-	managers.eventManager->RegisterEntityEvent("WeaponPickUp", pickUpEvent);
+	managers.eventManager->RegisterEntityEvent("ItemPickup", pickUpEvent);
 
 
 	auto wep = Item::Weapon::Create(Item::Weapon::Type::SWORD);
@@ -524,7 +524,7 @@ void SE::Gameplay::TutorialState::PickupWeaponScript(float dt)
 	};
 
 
-	managers.eventManager->RegisterEntityEvent("WeaponPickUp", pickUpEvent);
+	managers.eventManager->RegisterEntityEvent("ItemPickup", pickUpEvent);
 
 }
 

--- a/SluaghEngine/Gameplay/Weapon.cpp
+++ b/SluaghEngine/Gameplay/Weapon.cpp
@@ -7,7 +7,7 @@
 struct WeaponInfo
 {
 	SE::Utilz::GUID icon;
-	SE::Utilz::GUID iconP;
+	SE::Utilz::GUID selectedIcon;
 	SE::Utilz::GUID backTex;
 	SE::Utilz::GUID mesh;
 	SE::Utilz::GUID mat;
@@ -96,7 +96,7 @@ void SE::Gameplay::Item::Weapon::Equip(Core::Entity wep, Core::Entity to)
 {
 	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(wep, "Type", -1));
 
-	CoreInit::managers.guiManager->SetTexture(wep, weaponInfo[wType].iconP);
+	CoreInit::managers.guiManager->SetTexture(wep, weaponInfo[wType].selectedIcon);
 	CoreInit::managers.transformManager->SetPosition(wep, weaponInfo[wType].equipPos);
 	CoreInit::managers.transformManager->SetRotation(wep, weaponInfo[wType].equipRot.x, weaponInfo[wType].equipRot.y, weaponInfo[wType].equipRot.z);
 	CoreInit::managers.animationManager->AttachToEntity(to, wep, weaponInfo[wType].equipJoint, weaponInfo[wType].slotIndex);

--- a/SluaghEngine/Gameplay/Weapon.cpp
+++ b/SluaghEngine/Gameplay/Weapon.cpp
@@ -92,6 +92,70 @@ void SE::Gameplay::Item::Weapon::ToggleRenderEquiuppedInfo(Core::Entity wep, Cor
 
 }
 
+void SE::Gameplay::Item::Weapon::RenderItemInfo(Core::Entity item, Core::Entity compareWith)
+{
+	long posY = -40;
+	long textHeigth = 35;
+	Core::ITextManager::CreateInfo tci;
+	auto damage = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Damage", 0));
+	auto damageCW = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(compareWith, "Damage", 0));
+	if (damage > damageCW)
+		tci.info.colour = { 0, 1.0f, 0.0f, 1.0f };
+	else if (damage < damageCW)
+		tci.info.colour = { 1.0f, 0.0f, 0.0f, 1.0f };
+	else
+		tci.info.colour = { 1.0f, (165 / 255.0f), 0.0f, 1.0f };
+	tci.font = "CloisterBlack.spritefont";
+	tci.info.posX = -40;
+	tci.info.posY = posY;
+	tci.info.screenAnchor = { 0.5f, 0.5f };
+	tci.info.anchor = { 1.0f,0.0f };
+	tci.info.scale = { 0.4f, 1.0f };
+	tci.info.height = textHeigth;
+	tci.info.text = L"Skada";
+	auto textEnt = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.textManager->Create(textEnt, tci);
+	CoreInit::managers.textManager->ToggleRenderableText(textEnt, true);
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(textEnt, "StopRenderItemInfo");
+	posY += textHeigth + 5;
+
+	auto health = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Health", 0));
+	auto healthCW = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(compareWith, "Health", 0));
+	if (health > healthCW)
+		tci.info.colour = { 0, 1.0f, 0.0f, 1.0f };
+	else if (health < healthCW)
+		tci.info.colour = { 1.0f, 0.0f, 0.0f, 1.0f };
+	else
+		tci.info.colour = { 1.0f, (165 / 255.0f), 0.0f, 1.0f };
+	//tci.info.colour = { 1.0f, 1.0f, 1.0f, 1.0f };
+	tci.info.posY = posY;
+	tci.info.text = L"Hälsa";
+	textEnt = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.textManager->Create(textEnt, tci);
+	CoreInit::managers.textManager->ToggleRenderableText(textEnt, true);
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(textEnt, "StopRenderItemInfo");
+	posY += textHeigth + 5;
+
+
+	Core::IGUIManager::CreateInfo ciback;
+	auto type = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(item, "Type", -1));
+
+	ciback.texture = weaponInfo[type].backTex;
+	ciback.textureInfo.width = 125;
+	ciback.textureInfo.height = 125;
+	ciback.textureInfo.posX = -25;
+	ciback.textureInfo.posY = 0;
+	ciback.textureInfo.screenAnchor = { 0.5f, 0.5f };
+	ciback.textureInfo.anchor = { 1.0f, 0.5f };
+	auto weaponBack = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.guiManager->Create(weaponBack, ciback);
+
+	CoreInit::managers.guiManager->ToggleRenderableTexture(weaponBack, true);
+
+	CoreInit::managers.eventManager->RegisterEntitytoEvent(weaponBack, "StopRenderItemInfo");
+
+}
+
 void SE::Gameplay::Item::Weapon::Equip(Core::Entity wep, Core::Entity to)
 {
 	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(wep, "Type", -1));
@@ -101,7 +165,7 @@ void SE::Gameplay::Item::Weapon::Equip(Core::Entity wep, Core::Entity to)
 	CoreInit::managers.transformManager->SetRotation(wep, weaponInfo[wType].equipRot.x, weaponInfo[wType].equipRot.y, weaponInfo[wType].equipRot.z);
 	CoreInit::managers.animationManager->AttachToEntity(to, wep, weaponInfo[wType].equipJoint, weaponInfo[wType].slotIndex);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(wep, true);
-
+	CoreInit::managers.dataManager->SetValue(wep, "Equipped", true);
 }
 
 void SE::Gameplay::Item::Weapon::UnEquip(Core::Entity wep, Core::Entity from)
@@ -111,5 +175,5 @@ void SE::Gameplay::Item::Weapon::UnEquip(Core::Entity wep, Core::Entity from)
 	CoreInit::managers.guiManager->SetTexture(wep, weaponInfo[wType].icon);
 	CoreInit::managers.animationManager->DettachFromEntity(from, weaponInfo[wType].slotIndex);
 	CoreInit::managers.renderableManager->ToggleRenderableObject(wep, false);
-
+	CoreInit::managers.dataManager->SetValue(wep, "Equipped", false);
 }

--- a/SluaghEngine/Gameplay/Weapon.cpp
+++ b/SluaghEngine/Gameplay/Weapon.cpp
@@ -1,0 +1,115 @@
+#include <Weapon.h>
+#include "CoreInit.h"
+#include <Items.h>
+#include <array>
+#include <Stats.h>
+
+struct WeaponInfo
+{
+	SE::Utilz::GUID icon;
+	SE::Utilz::GUID iconP;
+	SE::Utilz::GUID backTex;
+	SE::Utilz::GUID mesh;
+	SE::Utilz::GUID mat;
+	SE::Utilz::GUID shader;
+	SE::Utilz::GUID projectile;
+	SE::Utilz::GUID attAnim;
+	SE::Utilz::GUID equipJoint;
+	int slotIndex;
+	DirectX::XMFLOAT3 equipPos;
+	DirectX::XMFLOAT3 scale;
+	DirectX::XMFLOAT3 equipRot;
+};
+
+static const std::array<WeaponInfo, 3> weaponInfo = { {
+	{ "Sword_black.png", "Sword2.png", "Physical.png", "Sword.mesh", "Sword.mat", "SimpleLightPS.hlsl", "playerMeleeProjectiles.SEP", "TopSwordAttackAnim_MCModell.anim", "LHand", 0,{ 0.2f, -0.1f, -0.5f },{ 1,1,1 },{ 3.0f, -0.4f, 1.3f } },
+	{ "Crossbow_black.png", "Crossbow_silver.png", "Range.png", "Crossbow.mesh", "Crossbow.mat", "SimpleLightPS.hlsl", "CrossbowAttack.SEP", "TopCrossbowAttackAnim_MCModell.anim" , "LHand", 0,{ 0, -0.02f, -0.25f },{ 0.15f,0.15f,0.15f },{ 1.6f, 1.2f,0.0f } },
+	{ "Wand_black.png","Wand_silver.png", "Magic.png", "WandPivotEnd.mesh", "WandPivotEnd.mat", "SimpleLightPS.hlsl", "WandAttack.SEP", "TopWandAttackAnim_MCModell.anim", "LHand", 0,{ 0.05f, 0.0f, -0.2f },{ 1,1,1 },{ 3.0f, -0.4f, 1.3f } }
+	} };
+
+
+
+SE::Core::Entity SE::Gameplay::Item::Weapon::Create()
+{
+	return Create(Weapon::Type(std::rand() % int(Weapon::Type::NONE)));
+}
+
+SE::Core::Entity SE::Gameplay::Item::Weapon::Create(Weapon::Type type)
+{
+	auto wep = CoreInit::managers.entityManager->Create();
+	CoreInit::managers.dataManager->SetValue(wep, "Item", int32_t(ItemType::WEAPON));
+	CoreInit::managers.dataManager->SetValue(wep, "Type", int32_t(type));
+	CoreInit::managers.dataManager->SetValue(wep, "Health", Stats::GetRandHealth());
+	CoreInit::managers.dataManager->SetValue(wep, "Str", Stats::GetRandStr());
+	CoreInit::managers.dataManager->SetValue(wep, "Agi", Stats::GetRandAgi());
+	CoreInit::managers.dataManager->SetValue(wep, "Wis", Stats::GetRandWil());
+	CoreInit::managers.dataManager->SetValue(wep, "Damage", 3);
+	CoreInit::managers.dataManager->SetValue(wep, "Element", int32_t(Stats::GetRandomDamageType()));
+	CoreInit::managers.dataManager->SetValue(wep, "AttAnim", weaponInfo[size_t(type)].attAnim.id);
+	CoreInit::managers.dataManager->SetValue(wep, "AttProj", weaponInfo[size_t(type)].projectile.id);
+	CreateMeta(wep);
+
+
+	return wep;
+}
+
+void SE::Gameplay::Item::Weapon::CreateMeta(SE::Core::Entity wep)
+{
+	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(wep, "Type", -1));
+	CoreInit::managers.transformManager->Create(wep);
+	CoreInit::managers.transformManager->SetScale(wep, weaponInfo[size_t(wType)].scale);
+	CoreInit::managers.materialManager->Create(wep, { weaponInfo[size_t(wType)].shader, weaponInfo[size_t(wType)].mat });
+	CoreInit::managers.renderableManager->CreateRenderableObject(wep, { weaponInfo[size_t(wType)].mesh , false, false, true });
+	Core::IGUIManager::CreateInfo icon;
+	icon.texture = weaponInfo[size_t(wType)].icon;
+	icon.textureInfo.width = 50;
+	icon.textureInfo.height = 50;
+	icon.textureInfo.anchor = { 0.5f,0.5f };
+	icon.textureInfo.screenAnchor = { 0, 1 };
+	icon.textureInfo.posX = 10;
+	icon.textureInfo.posY = -60;
+	icon.textureInfo.layerDepth = 0;
+
+	CoreInit::managers.guiManager->Create(wep, icon);
+}
+
+using namespace SE;
+static const auto wepInfo = [](SE::Core::Entity wep, Core::Entity parent, long posX, bool stop)
+{
+	
+};
+
+void SE::Gameplay::Item::Weapon::ToggleRenderPickupInfo(Core::Entity wep)
+{
+	wepInfo(wep, wep, -40, false);
+}
+
+void SE::Gameplay::Item::Weapon::ToggleRenderEquiuppedInfo(Core::Entity wep, Core::Entity parent)
+{
+
+	wepInfo(wep, parent, -245, true);
+
+
+}
+
+void SE::Gameplay::Item::Weapon::Equip(Core::Entity wep, Core::Entity to)
+{
+	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(wep, "Type", -1));
+
+	CoreInit::managers.guiManager->SetTexture(wep, weaponInfo[wType].iconP);
+	CoreInit::managers.transformManager->SetPosition(wep, weaponInfo[wType].equipPos);
+	CoreInit::managers.transformManager->SetRotation(wep, weaponInfo[wType].equipRot.x, weaponInfo[wType].equipRot.y, weaponInfo[wType].equipRot.z);
+	CoreInit::managers.animationManager->AttachToEntity(to, wep, weaponInfo[wType].equipJoint, weaponInfo[wType].slotIndex);
+	CoreInit::managers.renderableManager->ToggleRenderableObject(wep, true);
+
+}
+
+void SE::Gameplay::Item::Weapon::UnEquip(Core::Entity wep, Core::Entity from)
+{
+	auto wType = std::get<int32_t>(CoreInit::managers.dataManager->GetValue(wep, "Type", -1));
+
+	CoreInit::managers.guiManager->SetTexture(wep, weaponInfo[wType].icon);
+	CoreInit::managers.animationManager->DettachFromEntity(from, weaponInfo[wType].slotIndex);
+	CoreInit::managers.renderableManager->ToggleRenderableObject(wep, false);
+
+}

--- a/SluaghEngine/ResourceHandler/ResourceHandler.cpp
+++ b/SluaghEngine/ResourceHandler/ResourceHandler.cpp
@@ -154,7 +154,11 @@ static const auto invoke = [](auto& map, auto& guid, auto data, auto& callback, 
 		errors.Push_Back("Resource failed in InvokeCallback, GUID: " + std::to_string(guid.id));
 		return -1;
 	}
-
+	if (iresult & SE::ResourceHandler::InvokeReturn::SEMI_FAIL)
+	{
+		errors.Push_Back("Resource semi-failed in InvokeCallback, GUID: " + std::to_string(guid.id));
+		return -2;
+	}
 	if (iresult & SE::ResourceHandler::InvokeReturn::DEC_RAM)
 		SE::Utilz::OperateSingle(map, guid, decRef);
 	if (iresult & SE::ResourceHandler::InvokeReturn::DEC_VRAM)

--- a/SluaghEngine/includes/Gameplay/Consumable.h
+++ b/SluaghEngine/includes/Gameplay/Consumable.h
@@ -1,0 +1,20 @@
+#ifndef SE_GAMEPLAY_CONSUMABLE_H_
+#define SE_GAMEPLAY_CONSUMABLE_H_
+#include <Core\Entity.h>
+
+namespace SE::Gameplay::Item::Consumable
+{
+	enum class Type
+	{
+		HP,
+		NONE
+	};
+
+	Core::Entity Create();
+	Core::Entity Create(Type type);
+	void CreateMeta(Core::Entity ent);
+	void ToggleRenderPickupInfo(Core::Entity ent);
+	void ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent);
+}
+
+#endif //SE_GAMEPLAY_CONSUMABLE_H_

--- a/SluaghEngine/includes/Gameplay/Consumable.h
+++ b/SluaghEngine/includes/Gameplay/Consumable.h
@@ -15,6 +15,8 @@ namespace SE::Gameplay::Item::Consumable
 	void CreateMeta(Core::Entity ent);
 	void ToggleRenderPickupInfo(Core::Entity ent);
 	void ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent);
+
+	void RenderItemInfo(Core::Entity item, Core::Entity compareWith);
 }
 
 #endif //SE_GAMEPLAY_CONSUMABLE_H_

--- a/SluaghEngine/includes/Gameplay/EventStructs.h
+++ b/SluaghEngine/includes/Gameplay/EventStructs.h
@@ -76,6 +76,7 @@ namespace SE
 			NATURE,
 			RANGED,
 			MAGIC,
+			NUM_TYPES
 		};
 
 		/**

--- a/SluaghEngine/includes/Gameplay/Items.h
+++ b/SluaghEngine/includes/Gameplay/Items.h
@@ -1,6 +1,8 @@
-#ifndef SE_GAMEPLAY_WEAPON_H_
-#define SE_GAMEPLAY_WEAPON_H_
+#ifndef SE_GAMEPLAY_ITEMS_H_
+#define SE_GAMEPLAY_ITEMS_H_
 #include "Stats.h"
+#include "Weapon.h"
+#include "Consumable.h"
 #include <Utilz\GUID.h>
 #include <Core\Entity.h>
 #include <DirectXMath.h>
@@ -16,62 +18,45 @@ namespace SE
 			CONSUMABLE,
 			NUM_TYPES
 		};
-		enum class ConsumableType
-		{
-			HP
-		};
-		enum class WeaponType
-		{
-			SWORD,
-			CROSSBOW,
-			WAND,
-			NONE
-		};
-		struct Item
-		{
-			static Core::Entity Create();
+		
 
-			struct Consumable
+		namespace Item
+		{
+			Core::Entity Create();
+
+			/*struct Consumable
 			{
 				static Core::Entity Create();
 				static Core::Entity Create(ConsumableType type);
 				static void CreateMeta(Core::Entity ent);
 				static void ToggleRenderPickupInfo(Core::Entity ent);
 				static void ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent);
-			};
-			struct Weapon
-			{
-				static Core::Entity Create();
-				static Core::Entity Create(WeaponType type);
-				static void CreateMeta(Core::Entity ent);
-				static void ToggleRenderPickupInfo(Core::Entity ent);
-				static void ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent);
-			};
+			};*/
+			//struct Weapon
+			//{
+			//	static Core::Entity Create();
+			//	static Core::Entity Create(WeaponType type);
+			//	static void CreateMeta(Core::Entity ent);
+			//	static void ToggleRenderPickupInfo(Core::Entity ent);
+			//	static void ToggleRenderEquiuppedInfo(Core::Entity ent, Core::Entity parent);
+			//};
 			
-			static void Drop(Core::Entity ent, DirectX::XMFLOAT3 pos);
-			static void Drop(Core::Entity ent);
-			static void Pickup(Core::Entity ent);
-			static void GodPickup(Core::Entity ent);
-			static void Equip(Core::Entity to, Core::Entity ent);
-			static void Unequip(Core::Entity from, Core::Entity ent);
-			static void ToggleRenderPickupInfo(Core::Entity ent);
-			static void ToggleRenderEquiuppedInfo(Core::Entity item, Core::Entity parent);
-
-			static int GetRandStr();
-			static int GetRandAgi();
-			static int GetRandWil();
-			static int GetRandHealth();
-			static int GetRandDamage();
-
-			static DamageType GetRandDamageType();
+			void Drop(Core::Entity ent, DirectX::XMFLOAT3 pos);
+			void Drop(Core::Entity ent);
+			void Pickup(Core::Entity ent);
+			void GodPickup(Core::Entity ent);
+			void Equip(Core::Entity item, Core::Entity to);
+			void Unequip(Core::Entity item, Core::Entity from);
+			void ToggleRenderPickupInfo(Core::Entity ent);
+			void ToggleRenderEquiuppedInfo(Core::Entity item, Core::Entity parent);
 
 
-			static Core::Entity Copy(Core::Entity toCopy);
-			static void WriteToFile(Core::Entity ent,const std::string& filename);
-			static void WriteToFile(Core::Entity ent, std::ofstream& file);
+			Core::Entity Copy(Core::Entity toCopy);
+			void WriteToFile(Core::Entity ent,const std::string& filename);
+			void WriteToFile(Core::Entity ent, std::ofstream& file);
 
-			static Core::Entity Create(const std::string& filename);
-			static Core::Entity Create(std::ifstream& file);
+			Core::Entity Create(const std::string& filename);
+			Core::Entity Create(std::ifstream& file);
 		};
 	}
 }

--- a/SluaghEngine/includes/Gameplay/Items.h
+++ b/SluaghEngine/includes/Gameplay/Items.h
@@ -50,6 +50,7 @@ namespace SE
 			void ToggleRenderPickupInfo(Core::Entity ent);
 			void ToggleRenderEquiuppedInfo(Core::Entity item, Core::Entity parent);
 
+			void RenderItemInfo(Core::Entity item, Core::Entity compareWith);
 
 			Core::Entity Copy(Core::Entity toCopy);
 			void WriteToFile(Core::Entity ent,const std::string& filename);

--- a/SluaghEngine/includes/Gameplay/PlayerUnit.h
+++ b/SluaghEngine/includes/Gameplay/PlayerUnit.h
@@ -78,6 +78,7 @@ namespace SE
 			static const uint8_t MAX_ITEMS = 5;
 			Core::Entity items[MAX_ITEMS];
 			uint8_t currentItem = 0;
+			uint8_t showingItem = 0;
 			Core::Entity itemSelectedEntity;
 			Stats weaponStats;
 			bool displaying = false;
@@ -176,7 +177,10 @@ namespace SE
 			{
 				return items[currentItem];
 			}
-
+			inline Core::Entity GetItemToCompareWith()const
+			{
+				return items[showingItem];
+			}
 			/**
 			* @brief	Update the players movement
 			*

--- a/SluaghEngine/includes/Gameplay/Stats.h
+++ b/SluaghEngine/includes/Gameplay/Stats.h
@@ -11,13 +11,18 @@ namespace SE
 		{
 			//std::string characterName;
 			int str = 5;
+			static const int MAX_STR = 10;
 			int agi = 5;
+			static const int MAX_AGI = 10;
 			int whi = 5;
+			static const int MAX_WHI = 10;
 			int armorCap = 3;
 
 			//str
 			float health = 100.f;
+			static const int MAX_HEALTH = 100;
 			float damage = 1.f;
+			static const int MAX_DAMAGE = 15;
 			float meleeMultiplier = 1.f;
 			float physicalResistance = 1.f;
 
@@ -39,6 +44,32 @@ namespace SE
 			ArmourType armour = ArmourType::ARMOUR_TYPE_NONE;
 			DamageSources weapon = DamageSources::DAMAGE_SOURCE_MELEE;
 			DamageType damageType = DamageType::PHYSICAL;
+
+
+			inline static DamageType GetRandomDamageType()
+			{
+				return DamageType(std::rand() % int(DamageType::NUM_TYPES));
+			}
+			inline static int GetRandStr()
+			{
+				return std::rand() % (MAX_STR + 1) - MAX_STR;
+			}
+			inline static int GetRandAgi()
+			{
+				return std::rand() % (MAX_AGI + 1) - MAX_AGI;
+			}
+			inline static int GetRandWil()
+			{
+				return std::rand() % (MAX_WHI + 1) - MAX_WHI;
+			}
+			inline static int GetRandHealth()
+			{
+				return std::rand() % (MAX_HEALTH) + 1;
+			}
+			inline static int GetRandDamage()
+			{
+				return std::rand() % (MAX_DAMAGE) + 1;
+			}
 		};
 	}
 }

--- a/SluaghEngine/includes/Gameplay/Weapon.h
+++ b/SluaghEngine/includes/Gameplay/Weapon.h
@@ -16,6 +16,8 @@ namespace SE::Gameplay::Item::Weapon
 	void ToggleRenderPickupInfo(Core::Entity wep);
 	void ToggleRenderEquiuppedInfo(Core::Entity wep, Core::Entity parent);
 
+	void RenderItemInfo(Core::Entity item, Core::Entity compareWith);
+
 	void Equip(Core::Entity wep, Core::Entity to);
 	void UnEquip(Core::Entity wep, Core::Entity from);
 }

--- a/SluaghEngine/includes/Gameplay/Weapon.h
+++ b/SluaghEngine/includes/Gameplay/Weapon.h
@@ -1,0 +1,23 @@
+#ifndef SE_GAMEPLAY_WEAPON_H_
+#define SE_GAMEPLAY_WEAPON_H_
+#include <Core\Entity.h>
+namespace SE::Gameplay::Item::Weapon
+{
+	enum class Type
+	{
+		SWORD,
+		CROSSBOW,
+		WAND,
+		NONE
+	};
+	Core::Entity Create();
+	Core::Entity Create(Type type);
+	void CreateMeta(Core::Entity wep);
+	void ToggleRenderPickupInfo(Core::Entity wep);
+	void ToggleRenderEquiuppedInfo(Core::Entity wep, Core::Entity parent);
+
+	void Equip(Core::Entity wep, Core::Entity to);
+	void UnEquip(Core::Entity wep, Core::Entity from);
+}
+
+#endif

--- a/SluaghEngine/includes/ResourceHandler/IResourceHandler.h
+++ b/SluaghEngine/includes/ResourceHandler/IResourceHandler.h
@@ -36,14 +36,16 @@ namespace SE
 		{
 			SUCCESS = 1 << 0,
 			FAIL = 1 << 1,
-			NO_DELETE = 1 << 2
+			SEMI_FAIL = 1 << 2,
+			NO_DELETE = 1 << 3
 		};
 
 		enum class InvokeReturn {
 			FAIL = 1 << 1,
 			SUCCESS = 1 << 2,
 			DEC_RAM  = 1 << 3,
-			DEC_VRAM = 1 << 4
+			DEC_VRAM = 1 << 4,
+			SEMI_FAIL = 1 << 5
 		};
 
 		enum class LoadFlags {


### PR DESCRIPTION
Connected to issue #1220 

Additions:
* kill command, kills all enemies in the current room
* give command, give the player an item
* drop command, drop an item on the player
* Added a sword to the Sluagh in the tutorial.
* Added max stats to str, agi, whi, damage and health (Used for random cap)
-- Random stats can now be generated with ex. Stats::GetRandStr()

Changes: 
* Indications of whether or not an item on the ground is better has changed.
--  Numbers are no longer displayed
-- Info for currently equipped weapon can not be showed individually.
-- Green text indicated that the item on the ground has a higher stat than current.
-- Yellow indicates the same stats.
-- Red indicates worse.
* Item header refactor
-- Weapons moved to seperate header.
-- Consumables moved to seperate header.
-- More refined way of rendering the item info

New Issues:
#1232

Bugs Resolved: 
#1226 Added a new flag SEMI_FAIL to resource handler that is the same as FAIL except the resource handler will try to load it again.
#1219 Deleted the pointer

Warnings:
* Weapons and Consumables are now found under the namespace Item::Weapon and Item::Consumable
* WeaponType is now found under Item::Weapon::Type
* ConsumableType is now found under Item::Weapon::Type

- [x] I have a local backup of Latest Build/Asset.
- [ ] I have added new assets to Latest Build/Asset.
- [x] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
- [x] I have merged my branch with master and it works as expected.

![dasdas](https://user-images.githubusercontent.com/10143268/33383003-7bfa4f18-d522-11e7-9807-3b5801e1c06f.png)

