### PR TITLE
Windows in rooms #1222

### DIFF
--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -1232,6 +1232,7 @@ Room::Room(Utilz::GUID fileName)
 	Meshes[Meshes::Potatosack_open] = { "Potato_Sack_Open.mesh" };
 	Meshes[Meshes::Fireplace] = { "Fireplace.mesh" };
 	Meshes[Meshes::Painting] = { "Painting.mesh" };
+	Meshes[Meshes::Window] = { "Window.mesh" };
 
 
 	// Materials
@@ -1347,6 +1348,9 @@ Room::Room(Utilz::GUID fileName)
 	};
 	propItemToFunction[id_Door2] = [this](CreationArguments &args) {
 		this->CreateDoor(args);
+	};
+	propItemToFunction[id_Window] = [this](CreationArguments &args) {
+		this->CreateWindows(args);
 	};
 
 	RandomizeWallAndFloorTexture(wallTexture, floorTexture);
@@ -1567,13 +1571,13 @@ float Room::RotatePainting(int x, int y) {
 	float rotation = 0;
 
 
-	if ((tileValues[x - 1][y] == id_Floor))
+	if ( x < 24 && (tileValues[x + 1][y] == id_Floor))
 		rotation = 180;
-	else if ( (tileValues[x][y + 1] == id_Floor ))
+	else if ( y < 24 && (tileValues[x][y + 1] == id_Floor ))
 		rotation = 90;
-	else if ((tileValues[x][y - 1] == id_Floor ))
+	else if ( y > 0 &&(tileValues[x][y - 1] == id_Floor ))
 		rotation = -90;
-	else if ( (tileValues[x + 1][y] == id_Floor ))
+	else if ( x > 0  && (tileValues[x - 1][y] == id_Floor ))
 		rotation = 0;
 
 
@@ -1736,6 +1740,18 @@ void SE::Gameplay::Room::CreateFire(int x, int y)
 	//CoreInit::managers.particleSystemManager->ToggleVisible(entFire, true);
 	roomEntities[x][y].push_back(entFire);
 
+}
+void SE::Gameplay::Room::CreateWindows(CreationArguments & args)
+{
+	Core::IMaterialManager::CreateInfo matInfo;
+	matInfo.materialFile = Materials[Materials::Stone];
+	matInfo.shader = Norm;
+	CoreInit::managers.materialManager->Create(args.ent, matInfo);
+	CoreInit::managers.transformManager->SetPosition(args.ent, DirectX::XMFLOAT3(args.x + 0.5f, 1.5f, args.y + 0.5f));
+	CoreInit::managers.transformManager->SetRotation(args.ent, 0.0f, RotatePainting(args.x, args.y), 0.0f);
+	CoreInit::managers.renderableManager->CreateRenderableObject(args.ent, { Meshes[Meshes::Window] });
+
+	roomEntities[args.x][args.y].push_back(args.ent);
 }
 void SE::Gameplay::Room::CreateBush(CreationArguments &args)
 {

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -1244,18 +1244,13 @@ Room::Room(Utilz::GUID fileName)
 	Materials[Materials::Bush] = { "Bush.mat" };
 	Materials[Materials::Dirt] = { "brownPlane.mat" };
 	Materials[Materials::Grass] = { "GreenPlane.mat" };
-
 	Materials[Materials::Wood] = { "Wood_plane.mat" };
 	Materials[Materials::OutsideWall] = { "StoneWallPlane.mat" };
-
-
 	Materials[Materials::StoneFloor2] = { "StoneFloor2.mat" };
 	Materials[Materials::WoodFloor] = { "WoodFloor.mat" };
 	Materials[Materials::FanzyWall] = { "FanzyWall.mat" };
 	Materials[Materials::LightStoneWall] = { "LightStoneWall.mat" };
 	Materials[Materials::LightStoneWallWood] = { "LightStoneWallWood.mat" };
-
-
 	Materials[Materials::Window] = { "WindowOpen.mat" };
 
 

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -1924,18 +1924,18 @@ void SE::Gameplay::Room::CreateWall2(CreationArguments &args)
 
 	if (0 < randValue && randValue <= 10)
 	{
-		auto test = CoreInit::managers.entityManager->Create();
+		auto PaintingEnt = CoreInit::managers.entityManager->Create();
 		Core::IMaterialManager::CreateInfo matInfoPainting;
 		matInfoPainting.shader = Norm;
 		matInfoPainting.materialFile = Materials[Materials::Wood];
-		CoreInit::managers.transformManager->Create(test);
-		CoreInit::managers.transformManager->SetPosition(test, DirectX::XMFLOAT3(args.x + 0.5f, 1.0f, args.y + 0.5f));
-		CoreInit::managers.transformManager->SetRotation(test, 0.0f, RotatePainting(args.x, args.y), 0.0f);
-		CoreInit::managers.renderableManager->CreateRenderableObject(test, { Meshes[Meshes::Painting] });
-		CoreInit::managers.materialManager->Create(test, matInfoPainting);
+		CoreInit::managers.transformManager->Create(PaintingEnt);
+		CoreInit::managers.transformManager->SetPosition(PaintingEnt, DirectX::XMFLOAT3(args.x + 0.5f, 1.0f, args.y + 0.5f));
+		CoreInit::managers.transformManager->SetRotation(PaintingEnt, 0.0f, RotatePainting(args.x, args.y), 0.0f);
+		CoreInit::managers.renderableManager->CreateRenderableObject(PaintingEnt, { Meshes[Meshes::Painting] });
+		CoreInit::managers.materialManager->Create(PaintingEnt, matInfoPainting);
 		//CoreInit::managers.renderableManager->ToggleRenderableObject(test, true);
 
-		roomEntities[args.x][args.y].push_back(test);
+		roomEntities[args.x][args.y].push_back(PaintingEnt);
 
 	}
 

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -1256,6 +1256,8 @@ Room::Room(Utilz::GUID fileName)
 	Materials[Materials::LightStoneWallWood] = { "LightStoneWallWood.mat" };
 
 
+	Materials[Materials::Window] = { "WindowOpen.mat" };
+
 
 	Prop Chair;
 	Chair.guid = Meshes[Meshes::Chair];
@@ -1769,7 +1771,7 @@ void SE::Gameplay::Room::CreateWindows(CreationArguments & args)
 
 
 	Core::IMaterialManager::CreateInfo matInfo;
-	matInfo.materialFile = Materials[Materials::WoodFloor];
+	matInfo.materialFile = Materials[Materials::Window];
 	matInfo.shader = Norm;
 	CoreInit::managers.materialManager->Create(args.ent, matInfo);
 	CoreInit::managers.transformManager->SetPosition(args.ent, DirectX::XMFLOAT3(args.x + 0.5f, 1.5f, args.y + 0.5f));
@@ -1778,6 +1780,8 @@ void SE::Gameplay::Room::CreateWindows(CreationArguments & args)
 
 	roomEntities[args.x][args.y].push_back(args.ent);
 
+
+	// Base window mesh (wall)
 	auto entWindow = CoreInit::managers.entityManager->Create();
 	matInfo.materialFile = args.wallMat;
 	CoreInit::managers.transformManager->Create(entWindow);

--- a/SluaghEngine/includes/Gameplay/Room.h
+++ b/SluaghEngine/includes/Gameplay/Room.h
@@ -80,7 +80,9 @@ namespace SE
 				Potatosack_open,
 				Fireplace,
 				Painting,
-				Window
+				Window,
+				Window_open,
+				Window_closed
 			};
 			enum class Materials {
 				Stone,

--- a/SluaghEngine/includes/Gameplay/Room.h
+++ b/SluaghEngine/includes/Gameplay/Room.h
@@ -79,7 +79,8 @@ namespace SE
 				Potatosack_closed,
 				Potatosack_open,
 				Fireplace,
-				Painting
+				Painting,
+				Window
 			};
 			enum class Materials {
 				Stone,
@@ -131,6 +132,7 @@ namespace SE
 			static const char id_Wall     = 255;
 			static const char id_Pillar   = 225;
 			static const char id_Bush     = 13;
+			static const char id_Window = 180;
 			
 			/*Needed:
 			 * Representation of the room module(s) that build the room
@@ -644,6 +646,7 @@ namespace SE
 
 			void CreateFire(int x, int y);
 
+			void CreateWindows(CreationArguments &args);
 			/**
 			* @brief set Room door pointer to values
 			*/

--- a/SluaghEngine/includes/Gameplay/Room.h
+++ b/SluaghEngine/includes/Gameplay/Room.h
@@ -100,7 +100,8 @@ namespace SE
 				WoodFloor,
 				FanzyWall,
 				LightStoneWall,
-				LightStoneWallWood
+				LightStoneWallWood,
+				Window
 			};
 
 			struct CreationArguments


### PR DESCRIPTION
Connected to issue #1222

Additions:
* Added support for windows, mesh and mat
* Windows to the left (west) will always be closed as per the mythology

Changes: 
* Added new function (CreateWindows) to room.cpp

Texture needs to be added. UV also needs adjusting. This will be done separately.

- [x] -- I have checked all the boxes. --
- [x] I have a local backup of Latest Build/Asset.
- [ ] I have added new assets to Latest Build/Asset.
- [x] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
- [x] I have merged my branch with master and it works as expected.