### PR TITLE
Decal placement

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,1 +1,13 @@
-This is a test
+-- Everything marked like this must be removed --
+
+Who wants it:
+Peter and Torbjörn
+
+What they want:
+The issue template should contain.
+- [x] Who wants it.
+- [ ] What does the issue entail? A description and and a checkbox for everything that needs to be done.
+- [ ] Why do they want it? Why is it good and what does it entail?
+
+Why they want it:
+Templates are nice and helps document the development process.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,9 +25,9 @@ Notes -- Anything noteworthy. If none remove --
 I like trains.
 
 - [x] -- I have checked all the boxes. --
-- [] I have a local backup of Latest Build/Asset.
-- [] This PR adds assets to Latest Build/Asset.
-- [] I have added the new assets to Latest Build/Asset
-- [] This PR changes assets in Latest Build/Asset.
-- [] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
-- [] I have merged my branch with master and it works as expected.
+- [ ] I have a local backup of Latest Build/Asset.
+- [ ] This PR adds assets to Latest Build/Asset.
+- [ ] I have added the new assets to Latest Build/Asset
+- [ ] This PR changes assets in Latest Build/Asset.
+- [ ] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
+- [ ] I have merged my branch with master and it works as expected.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,21 @@
 
 Connected to issue #nr
 
-Additions:
-* Added a pull request template
+Additions: -- New Things --
+Added a pull request template
+* Additions
+* Changes
+* New Issues
+* Bugs Resolved
+* New bugs
+* Warnings
+* Notes
+* Checklist
 
-Changes: 
-* Added changes example to template
+
+Changes: -- Changes to something already existing --
+Changed the text under Additions
+* Additions now contains a list of all areas.
 -- This is related to the above point.
 
 New Issues: -- If none remove --

--- a/SluaghEngine/Core/DecalManager.cpp
+++ b/SluaghEngine/Core/DecalManager.cpp
@@ -79,7 +79,7 @@ SE::Core::DecalManager::DecalManager(const IDecalManager::InitializationInfo& in
 	cachedViewProj = DirectX::XMLoadFloat4x4(&vp);
 
 	initInfo.transformManager->RegisterSetDirty({ this, &DecalManager::SetDirty });
-	
+	initInfo.eventManager->RegisterToToggleVisible({ this, &DecalManager::ToggleVisible });
 }
 
 SE::Core::DecalManager::~DecalManager()
@@ -169,7 +169,7 @@ int SE::Core::DecalManager::Create(const Entity& entity, const DecalCreateInfo& 
 		});
 	}
 	entities.push_back(entity);
-
+	ToggleVisible(entity, false);
 	ProfileReturnConst(0);
 }
 
@@ -239,7 +239,14 @@ int SE::Core::DecalManager::Remove(const Entity& entity)
 
 void SE::Core::DecalManager::ToggleVisible(const Entity& entity, bool visible)
 {
-
+	const auto tex = entityToTextureGuid.find(entity);
+	if (tex != entityToTextureGuid.end())
+	{
+		const auto index = entityToTransformIndex[entity];
+		float& op = decalToTransforms[tex->second].opacity[index];
+		if ((!visible && op < 0.0f) || (visible && op > 0.0f))
+			op = -op;
+	}
 }
 
 void SE::Core::DecalManager::SetDirty(const Entity& entity, size_t index)

--- a/SluaghEngine/Core/DecalManager.cpp
+++ b/SluaghEngine/Core/DecalManager.cpp
@@ -237,6 +237,11 @@ int SE::Core::DecalManager::Remove(const Entity& entity)
 	ProfileReturn(index != -1 ? 0 : -1);
 }
 
+void SE::Core::DecalManager::ToggleVisible(const Entity& entity, bool visible)
+{
+
+}
+
 void SE::Core::DecalManager::SetDirty(const Entity& entity, size_t index)
 {
 	StartProfile;

--- a/SluaghEngine/Core/DecalManager.cpp
+++ b/SluaghEngine/Core/DecalManager.cpp
@@ -244,7 +244,7 @@ void SE::Core::DecalManager::ToggleVisible(const Entity& entity, bool visible)
 	{
 		const auto index = entityToTransformIndex[entity];
 		float& op = decalToTransforms[tex->second].opacity[index];
-		if ((!visible && op < 0.0f) || (visible && op > 0.0f))
+		if ((visible && op < 0.0f) || (!visible && op > 0.0f))
 			op = -op;
 	}
 }

--- a/SluaghEngine/Core/DecalManager.h
+++ b/SluaghEngine/Core/DecalManager.h
@@ -38,6 +38,11 @@ namespace SE
 			*/
 			int Remove(const Entity& entity) override;
 
+			/*
+			* @brief See IDecalManager
+			*/
+			void ToggleVisible(const Entity& entity, bool visible)override;
+
 			void Destroy(const Entity& entity) override;
 
 		private:

--- a/SluaghEngine/Gameplay/PlayState.cpp
+++ b/SluaghEngine/Gameplay/PlayState.cpp
@@ -215,6 +215,8 @@ PlayState::PlayState(Window::IWindow* Input, SE::Core::IEngine* engine, void* pa
 	currentRoom->RenderRoom(true);
 	currentRoom->InitializeAdjacentFlowFields();
 
+	CoreInit::subSystems.window->MapActionButton(Window::KeyReturn, Window::KeyReturn);
+
 	ProfileReturnVoid;
 }
 
@@ -1119,13 +1121,18 @@ IGameState::State PlayState::Update(void*& passableInfo)
 
 	if(deathSequence == true){
 
+		if (CoreInit::subSystems.window->ButtonPressed(Window::KeyReturn)) {
+
+			returnValue = State::CHARACTER_CREATION_STATE;
+		}
+
 		deathTimer += dt;
 
 		UpdateDeathCamera(dt, -0.5f, 0.2f, 3.0f);
 		
 		if (deathTimer > 15){
 			deathTimer = 0.0f;
-			returnValue = State::MAIN_MENU_STATE;
+			returnValue = State::CHARACTER_CREATION_STATE;
 		}
 	}
 

--- a/SluaghEngine/Gameplay/PlayState.cpp
+++ b/SluaghEngine/Gameplay/PlayState.cpp
@@ -240,6 +240,7 @@ PlayState::~PlayState()
 	CoreInit::managers.entityManager->DestroyNow(dummy);
 	CoreInit::managers.entityManager->DestroyNow(cameraDummy);
 	CoreInit::managers.entityManager->DestroyNow(deathText);
+	CoreInit::managers.entityManager->DestroyNow(returnPrompt);
 	CoreInit::managers.entityManager->DestroyNow(usePrompt);
 	CoreInit::managers.entityManager->DestroyNow(soundEnt);
 	for (auto& s : skillIndicators)
@@ -493,6 +494,8 @@ std::wstring SE::Gameplay::PlayState::GenerateDeathMessage() {
 void SE::Gameplay::PlayState::InitializeDeathSequence() {
 
 	deathText = CoreInit::managers.entityManager->Create();
+	returnPrompt = CoreInit::managers.entityManager->Create();
+
 	Core::ITextManager::CreateInfo deathInfo;
 	deathInfo.info.text = GenerateDeathMessage();
 	deathInfo.info.scale = { 0.7f, 0.7f };
@@ -501,11 +504,22 @@ void SE::Gameplay::PlayState::InitializeDeathSequence() {
 	deathInfo.info.anchor = { 0.5f, 0.5f };
 	deathInfo.info.screenAnchor = { 0.5f, 0.25f };
 	deathInfo.font = "Knights.spritefont";
+
 	CoreInit::managers.textManager->Create(deathText, deathInfo);
 
+	deathInfo.info.text = L"TRYCK RETUR FÖR ATT ÅTERGÅ TILL MENYN";
+	deathInfo.info.scale = { 0.3f, 0.3f };
+	deathInfo.info.posX = 0;
+	deathInfo.info.posY = 0;
+	deathInfo.info.anchor = { 0.5f, 0.5f };
+	deathInfo.info.screenAnchor = { 0.5f, 0.90f };
+
+	CoreInit::managers.textManager->Create(returnPrompt, deathInfo);
+
 	CoreInit::managers.textManager->SetTextColour(deathText, XMFLOAT4{ 1.0f, 0.0f, 0.0f, 1.0f });
-	//CoreInit::managers.textManager->SetTextPos(deathText, CoreInit::subSystems.window->Width() / 2, CoreInit::subSystems.window->Height() / 2);
+	CoreInit::managers.textManager->SetTextColour(returnPrompt, XMFLOAT4{ 1.0f, 0.0f, 0.0f, 1.0f });
 	CoreInit::managers.textManager->ToggleRenderableText(deathText, true);
+	CoreInit::managers.textManager->ToggleRenderableText(returnPrompt, true);
 
 	// Create dummy entity and initialize it with player position
 	cameraDummy = CoreInit::managers.entityManager->Create();

--- a/SluaghEngine/Gameplay/Room.cpp
+++ b/SluaghEngine/Gameplay/Room.cpp
@@ -1974,6 +1974,22 @@ void SE::Gameplay::Room::CreateWall2(CreationArguments &args)
 		CoreInit::managers.renderableManager->CreateRenderableObject(PaintingEnt, { Meshes[Meshes::Painting] });
 		CoreInit::managers.materialManager->Create(PaintingEnt, matInfoPainting);
 		//CoreInit::managers.renderableManager->ToggleRenderableObject(test, true);
+		
+		Core::DecalCreateInfo decalInfo;
+		decalInfo.opacity = 0.50f;
+		decalInfo.textureName = "painting1.png";
+
+		CoreInit::managers.decalManager->Create(PaintingEnt, decalInfo);
+		//CoreInit::managers.decalManager->ToggleVisible(PaintingEnt, true);
+
+		DirectX::XMFLOAT3 paintingForward = CoreInit::managers.transformManager->GetForward(PaintingEnt);
+
+		DirectX::XMFLOAT4X4 decalTrans;
+		DirectX::XMMATRIX decalTranslation = DirectX::XMMatrixTranslation(0.0f + paintingForward.x * 0.25f, 0.75f, 0.0f + paintingForward.z * 0.25f);
+		DirectX::XMMATRIX decalScaling = DirectX::XMMatrixScaling(0.945f, 1.14f, 0.65f);
+		DirectX::XMStoreFloat4x4(&decalTrans, decalScaling * decalTranslation);
+
+		CoreInit::managers.decalManager->SetLocalTransform(PaintingEnt, (float*)&decalTrans);
 
 		roomEntities[args.x][args.y].push_back(PaintingEnt);
 

--- a/SluaghEngine/includes/Core/IDecalManager.h
+++ b/SluaghEngine/includes/Core/IDecalManager.h
@@ -82,6 +82,13 @@ namespace SE
 			 */
 			virtual int Remove(const Entity& entity) = 0;
 
+			/*
+			* @brief Toggles visibility of a decal
+			* @param[in] entity The entity to toggle the visibility of
+			* @param[in] visible true for on, false for off.
+			*/
+			virtual void ToggleVisible(const Entity& entity, bool visible) = 0;
+
 		private:
 
 		protected:

--- a/SluaghEngine/includes/Gameplay/PlayState.h
+++ b/SluaghEngine/includes/Gameplay/PlayState.h
@@ -85,6 +85,7 @@ namespace SE
 			Core::Entity cam;
 			Core::Entity dummy;
 			Core::Entity usePrompt;
+			Core::Entity returnPrompt;
 			PlayerUnit* player;
 
 			uint8_t worldWidth = 4;


### PR DESCRIPTION
Connected to issue #1242

Changes: 
Decals had to be able to be created without being visible at start. When this was fixed, a decal was placed on a painting.

New Bugs:
After the player has died and returns to the menu, the buttons in the character creation state are flashing

Notes:
Paintings can now have decals

- [x] I have a local backup of Latest Build/Asset.
- [x] This PR adds assets to Latest Build/Asset.
- [x] I have added the new assets to Latest Build/Asset
- [ ] This PR changes assets in Latest Build/Asset.
- [x] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
- [x] I have merged my branch with master and it works as expected.
