### PR TITLE
Pause menu

### DIFF
--- a/SluaghEngine/Gameplay/Game.cpp
+++ b/SluaghEngine/Gameplay/Game.cpp
@@ -99,6 +99,7 @@ void SE::Gameplay::Game::Run()
 					buttonsExist = false;
 				}
 				paused = !paused;
+				CoreInit::subSystems.window->ToggleCursor(true);
 
 			}
 			else {

--- a/SluaghEngine/Gameplay/Game.cpp
+++ b/SluaghEngine/Gameplay/Game.cpp
@@ -185,8 +185,8 @@ void SE::Gameplay::Game::Run()
 		else {
 			if (!buttonsExist)
 			{
-				fileParser.GUIButtons.CreateButton(540, 90, 200, 80, 2, "ResumeButton", resume, false, "NULL", "bak.png", "bak1.png", "bak.png");
-				fileParser.GUIButtons.CreateButton(540, 200, 200, 80, 2, "ShutdownButton", shutDown, false, "NULL", "Avsluta.png", "Avsluta1.png", "Avsluta.png");
+				fileParser.GUIButtons.CreateButton(540, 200, 200, 80, 2, "ResumeButton", resume, false, "NULL", "bak.png", "bak1.png", "bak.png");
+				fileParser.GUIButtons.CreateButton(540, 350, 200, 80, 2, "ShutdownButton", shutDown, false, "NULL", "Avsluta.png", "Avsluta1.png", "Avsluta.png");
 				fileParser.GUIButtons.CreateButton(0, 0, 1280, 720, 1, "BackGround", NULL, false, "NULL", "bakgrund.png", "bakgrund.png", "bakgrund.png");
 				fileParser.GUIButtons.DrawButtons();
 				buttonsExist = true;

--- a/SluaghEngine/Gameplay/Game.cpp
+++ b/SluaghEngine/Gameplay/Game.cpp
@@ -72,21 +72,39 @@ void SE::Gameplay::Game::Run()
 	{
 		this->running = false;
 	};
+
 	std::function<void()> shutDown = quitGame;
 
+	auto resumeGame = [this]()->void
+	{
+		this->paused = false;
+		this->buttonsExist = false;
+		this->fileParser.GUIButtons.DeleteButtons();
+	};
+
+	std::function<void()> resume = resumeGame;
+	
+	
 	while (running)
 	{
 		CoreInit::engine->BeginFrame();
 
 		if (CoreInit::subSystems.window->ButtonPressed(uint32_t(GameInput::EXIT_GAME)))
 		{
-			if (paused == true)
+			if (currentState != SE::Gameplay::IGameState::State::MAIN_MENU_STATE)
 			{
-				fileParser.GUIButtons.DeleteButtons();
-				buttonsExist = false;
+				if (paused == true)
+				{
+					fileParser.GUIButtons.DeleteButtons();
+					buttonsExist = false;
+				}
+				paused = !paused;
+
 			}
-			paused = !paused;
-			//running = false;
+			else {
+				running = false;
+			}
+
 		}
 
 		if (!paused)
@@ -167,11 +185,18 @@ void SE::Gameplay::Game::Run()
 		else {
 			if (!buttonsExist)
 			{
-				fileParser.GUIButtons.CreateButton(500, 90, 150, 50, 1, "ResumeButton", shutDown);
-				fileParser.GUIButtons.CreateButton(500, 200, 150, 50, 1, "ShutdownButton", shutDown);
+				fileParser.GUIButtons.CreateButton(540, 90, 200, 80, 2, "ResumeButton", resume, false, "NULL", "bak.png", "bak1.png", "bak.png");
+				fileParser.GUIButtons.CreateButton(540, 200, 200, 80, 2, "ShutdownButton", shutDown, false, "NULL", "Avsluta.png", "Avsluta1.png", "Avsluta.png");
+				fileParser.GUIButtons.CreateButton(0, 0, 1280, 720, 1, "BackGround", NULL, false, "NULL", "bakgrund.png", "bakgrund.png", "bakgrund.png");
 				fileParser.GUIButtons.DrawButtons();
 				buttonsExist = true;
 			}
+
+			bool pressed = CoreInit::subSystems.window->ButtonDown(uint32_t(GameInput::ACTION));
+			bool released = CoreInit::subSystems.window->ButtonUp(uint32_t(GameInput::ACTION));
+			int mousePosX, mousePosY;
+			CoreInit::subSystems.window->GetMousePos(mousePosX, mousePosY);
+			fileParser.GUIButtons.ButtonHover(mousePosX, mousePosY, pressed, released);
 		}
 			CoreInit::engine->EndFrame();
 	}

--- a/SluaghEngine/Gameplay/Game.cpp
+++ b/SluaghEngine/Gameplay/Game.cpp
@@ -56,6 +56,7 @@ void SE::Gameplay::Game::Initiate(Core::IEngine* engine)
 	currentState = SE::Gameplay::IGameState::State::MAIN_MENU_STATE;
 	paused = false;
 	running = true;
+	buttonsExist = false;
 }
 
 void SE::Gameplay::Game::Run()
@@ -67,11 +68,11 @@ void SE::Gameplay::Game::Run()
 	CoreInit::engine->GetSubsystems().window->UpdateTime();
 	//!CoreInit::subSystems.window->ButtonPressed(uint32_t(GameInput::EXIT_GAME))
 
-	/*auto quitGame = [this]()->void
+	auto quitGame = [this]()->void
 	{
 		this->running = false;
 	};
-	std::function<void()> shutDown = quitGame;*/
+	std::function<void()> shutDown = quitGame;
 
 	while (running)
 	{
@@ -79,8 +80,13 @@ void SE::Gameplay::Game::Run()
 
 		if (CoreInit::subSystems.window->ButtonPressed(uint32_t(GameInput::EXIT_GAME)))
 		{
-			//paused = !paused;
-			running = false;
+			if (paused == true)
+			{
+				fileParser.GUIButtons.DeleteButtons();
+				buttonsExist = false;
+			}
+			paused = !paused;
+			//running = false;
 		}
 
 		if (!paused)
@@ -159,8 +165,13 @@ void SE::Gameplay::Game::Run()
 
 		}
 		else {
-			/*fileParser.GUIButtons.CreateButton(500, 500, 150, 50, 1, "ShutdownButton", shutDown);
-			fileParser.GUIButtons.DrawButtons();*/
+			if (!buttonsExist)
+			{
+				fileParser.GUIButtons.CreateButton(500, 90, 150, 50, 1, "ResumeButton", shutDown);
+				fileParser.GUIButtons.CreateButton(500, 200, 150, 50, 1, "ShutdownButton", shutDown);
+				fileParser.GUIButtons.DrawButtons();
+				buttonsExist = true;
+			}
 		}
 			CoreInit::engine->EndFrame();
 	}

--- a/SluaghEngine/Gameplay/Game.cpp
+++ b/SluaghEngine/Gameplay/Game.cpp
@@ -91,7 +91,7 @@ void SE::Gameplay::Game::Run()
 
 		if (CoreInit::subSystems.window->ButtonPressed(uint32_t(GameInput::EXIT_GAME)))
 		{
-			if (currentState != SE::Gameplay::IGameState::State::MAIN_MENU_STATE)
+			if (currentState != SE::Gameplay::IGameState::State::MAIN_MENU_STATE || SE::Gameplay::IGameState::State::OPTION_STATE || SE::Gameplay::IGameState::State::CHARACTER_CREATION_STATE)
 			{
 				if (paused == true)
 				{

--- a/SluaghEngine/includes/Gameplay/Game.h
+++ b/SluaghEngine/includes/Gameplay/Game.h
@@ -23,10 +23,11 @@ namespace SE
 			IGameState* state;
 			bool paused;
 			bool running;
+			bool buttonsExist;
 			Window::IWindow* input;
 			SE::Core::IEngine* engine;
 			SE::Gameplay::IGameState::State currentState;
-			//HUDParser fileParser;
+			HUDParser fileParser;
 
 		public:
 			void Initiate(Core::IEngine* engine);


### PR DESCRIPTION
Connected to issue #1289 

Additions:
*Pause menu with working buttons to keep playing or exit the game

Changes:
* Escape key will bring up the pause menu in game. In the main menu it will exit as normal


New Bugs:
* The hover texture only works the first time the menu is opened. If we open it again and hover over a button, nothing happens. We can still click it like normal.
-- Connected to issue #1290


Notes:
* Better textures need to be made to indicate function of the buttons

- [x] I have a local backup of Latest Build/Asset.
- [ ] This PR adds assets to Latest Build/Asset.
- [x] I have added the new assets to Latest Build/Asset
- [ ] This PR changes assets in Latest Build/Asset.
- [x] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
- [x] I have merged my branch with master and it works as expected.
