### PR TITLE
Minimap Adjacent Room Display Fix. Issue #1364

### DIFF
--- a/SluaghEngine/Gameplay/PlayState.cpp
+++ b/SluaghEngine/Gameplay/PlayState.cpp
@@ -480,12 +480,11 @@ void SE::Gameplay::PlayState::CheckForRoomTransition()
 			if (auto newRoom = GetRoom(x, y); newRoom.has_value())
 			{
 				// Set new room symbol to green
-				auto debug = newRoom->get().symbol;
 				CoreInit::managers.guiManager->SetTexture(newRoom->get().symbol, "InRoom.jpg");
 				CoreInit::managers.guiManager->ToggleRenderableTexture(newRoom->get().symbol, true);
 
 				// Grey out the symbol of the old room and set it to visitéd
-				auto oldRoom = GetRoom(currentRoomX, currentRoomY)->get();
+				auto& oldRoom = GetRoom(currentRoomX, currentRoomY)->get();
 				CoreInit::managers.guiManager->SetTexture(oldRoom.symbol, "VisitedRoom.jpg");
 				oldRoom.visited = true;
 
@@ -736,6 +735,7 @@ void SE::Gameplay::PlayState::LoadAdjacentRooms(int x, int y, int sx, int sy)
 					CoreInit::managers.guiManager->SetTexture(adjRoom->get().symbol, "EmptyRoom.jpg");
 					CoreInit::managers.guiManager->ToggleRenderableTexture(adjRoom->get().symbol, true);
 				}
+
 			}
 		}
 	}


### PR DESCRIPTION
Connected to issue #1364

Changes: 
Made sure already visited adjacent rooms were not overwritten

- [x] I have a local backup of Latest Build/Asset.
- [ ] This PR adds assets to Latest Build/Asset.
- [ ] I have added the new assets to Latest Build/Asset
- [ ] This PR changes assets in Latest Build/Asset.
- [ ] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
- [x] I have merged my branch with master and it works as expected.