### PR TITLE
Fixed memory leak when chaning state

### DIFF
--- a/SluaghEngine/Gameplay/Game.cpp
+++ b/SluaghEngine/Gameplay/Game.cpp
@@ -128,6 +128,10 @@ void SE::Gameplay::Game::Run()
 				/*if (currentState == SE::Gameplay::IGameState::State::PLAY_STATE || currentState == SE::Gameplay::IGameState::State::CHARACTER_CREATION_STATE)
 					CoreInit::subSystems.window->StopRecording();*/
 				delete state;
+				if (currentState == SE::Gameplay::IGameState::State::PAUSE_STATE)
+				{
+					delete tempState;
+				}
 				CoreInit::managers.entityManager->DestroyAll();
 				state = new SE::Gameplay::MainMenuState(CoreInit::subSystems.window);
 				break;


### PR DESCRIPTION
Connected to issue #1384 

Changes:
* Now removes the playstate thats in tempState when switching from pause menu to main menu

- [ ] I have a local backup of Latest Build/Asset.
- [ ] This PR adds assets to Latest Build/Asset.
- [ ] I have added the new assets to Latest Build/Asset
- [ ] This PR changes assets in Latest Build/Asset.
- [ ] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
- [ ] I have merged my branch with master and it works as expected.
