### PR TITLE
Fixed button text error and added last skill button

### DIFF
--- a/SluaghEngine/Gameplay/HUD_Functionality.cpp
+++ b/SluaghEngine/Gameplay/HUD_Functionality.cpp
@@ -1044,6 +1044,20 @@ namespace SE
 			std::wstring text;
 			text.assign(button.buttonText.begin(), button.buttonText.end());
 
+
+			int width = button.Width;
+			int height = button.Height;
+			int posX = button.PositionX;
+			int posY = button.PositionY;
+			bool perhaps=false;
+			bool fullscreen = CoreInit::subSystems.optionsHandler->GetOptionBool("Window", "fullScreen", perhaps);
+			if (fullscreen)
+			{
+				
+				reverseScreenPositions(width, height, posX, posY, true);
+			}
+
+
 			Graphics::TextGUI guiText;
 			guiText.colour = DirectX::XMFLOAT4(1.0, 1.0, 1.0, 1.0);
 			guiText.effect = Graphics::Effect::NoEffect;
@@ -1052,10 +1066,10 @@ namespace SE
 			guiText.layerDepth = 0;
 			guiText.anchor = DirectX::XMFLOAT2(0, 0);
 			guiText.screenAnchor = DirectX::XMFLOAT2(0, 0);
-			guiText.posX = button.PositionX + 5;
-			guiText.posY = button.PositionY + 5;
-			guiText.width = button.Width - 5;
-			guiText.height = button.Height - 5;
+			guiText.posX = posX + 5;
+			guiText.posY = posY + 5;
+			guiText.width = width - 5;
+			guiText.height = height - 5;
 			guiText.rotation = 0;
 			guiText.scale = DirectX::XMFLOAT2(0.9, 0.9);
 


### PR DESCRIPTION
 

Connected to issue #nr
None, standalone fix

Additions: 
Last skill button




Bugs Resolved: 
#1409
can now rezise window and button text follows accordingly




- [x] -- I have checked all the boxes. --
- [x] I have a local backup of Latest Build/Asset.
- [x] This PR adds assets to Latest Build/Asset.
- [x] I have added the new assets to Latest Build/Asset
- [ ] This PR changes assets in Latest Build/Asset.
- [ ] I have NOT overwritten any existing assets in Latest Build/Asset. (Only after merge is this allowed).
- [x] I have merged my branch with master and it works as expected.
